### PR TITLE
feat: #6 PeriodOption Entity 생성 & Product와 양방향 매핑

### DIFF
--- a/travel/src/main/java/com/travel/product/entity/PeriodOption.java
+++ b/travel/src/main/java/com/travel/product/entity/PeriodOption.java
@@ -1,0 +1,58 @@
+package com.travel.product.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.Period;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "period_option")
+public class PeriodOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "period_option_id")
+    private Long periodOptionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "period")
+    private Integer period;
+
+    //최대 인원
+    @Column(name = "period_option_maximum_quantity")
+    private Integer periodOptionMaximumQuantity;
+
+    //최소 인원
+    @Column(name = "period_option_minimum_quantity")
+    private Integer periodOptionMinimumQuantity;
+
+    //현재 신청한 인원
+    @Column(name = "period_option_sold_quantity")
+    private Integer periodOptionSoldQuantity;
+
+    @Builder
+    public PeriodOption(Product product, LocalDate startDate, LocalDate endDate, Integer periodOptionMaximumQuantity, Integer periodOptionMinimumQuantity, Integer periodOptionSoldQuantity) {
+        this.product = product;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.period = Period.between(startDate, endDate).getDays() + 1;
+        this.periodOptionMaximumQuantity = periodOptionMaximumQuantity;
+        this.periodOptionMinimumQuantity = periodOptionMinimumQuantity;
+        this.periodOptionSoldQuantity = periodOptionSoldQuantity;
+    }
+}

--- a/travel/src/main/java/com/travel/product/entity/Product.java
+++ b/travel/src/main/java/com/travel/product/entity/Product.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDate;
-import java.time.Period;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -38,47 +38,20 @@ public class Product extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Status productStatus;
 
-    //최대 인원
-    @Column(name = "maximum_quantity")
-    private Integer productMaximumQuantity;
-
-    //최소 인원
-    @Column(name = "minimum_quantity")
-    private Integer productMinimumQuantity;
-
-    //현재 신청한 인원
-    @Column(name = "sold_quantity")
-    private Integer productSoldQuantity;
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "product", cascade = CascadeType.ALL)
+    private List<PeriodOption> periodOptions = new ArrayList<>();
 
     @Column(name = "product_detail")
     private String productDetail;
 
-    @Column(name = "start_date")
-    private LocalDate startDate;
-
-    @Column(name = "end_date")
-    private LocalDate endDate;
-
-    @Column(name = "period")
-    private Integer period;
-
     @Builder
-    public Product(String productName, String productThumbnail, Integer productPrice, Category productCategory, Status productStatus, Integer productMaximumQuantity, Integer productMinimumQuantity, Integer productSoldQuantity, String productDetail, LocalDate startDate, LocalDate endDate) {
+    public Product(String productName, String productThumbnail, Integer productPrice, Category productCategory, String productDetail) {
         this.productName = productName;
         this.productThumbnail = productThumbnail;
         this.productPrice = productPrice;
         this.productCategory = productCategory;
-        this.productStatus = productStatus;
-        this.productMaximumQuantity = productMaximumQuantity;
-        this.productMinimumQuantity = productMinimumQuantity;
-        this.productSoldQuantity = productSoldQuantity;
         this.productDetail = productDetail;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.period = Period.between(startDate, endDate).getDays() + 1;
-
     }
-
     /*
     @ElementCollection
     @CollectionTable(name = "image")


### PR DESCRIPTION
## Motivation

하나의 상품에 다양한 필수적인 기간 옵션을 기획
상품과 옵션간의 양방향 매핑이 필요

참고로 OneToMany 매핑이 필요하면 fk가 Many쪽에 있기 때문에
단방향대신 양방향으로 묶고 양방향 편의 메소드 생성을 권장

## Key Changes

- Change 1
- https://github.com/KDT3-Final-6/final-project-BE/issues/6
    - e1fb8fec : 위 이슈와 관련된 PeriodOption(다) <-> Product(일) 양방향 매핑

## To reviewers

OneToMany 매핑이 필요하면 fk가 Many쪽에 있기 때문에
단방향대신 양방향으로 묶고 양방향 편의 메소드 생성을 권장하여
이를 적용

