### PR TITLE
GlobalException 구현

### DIFF
--- a/travel/src/main/java/com/travel/global/exception/CustomException.java
+++ b/travel/src/main/java/com/travel/global/exception/CustomException.java
@@ -1,0 +1,7 @@
+package com.travel.global.exception;
+
+public abstract class CustomException extends RuntimeException{
+
+    public abstract CustomExceptionType getCustomExceptionType();
+
+}

--- a/travel/src/main/java/com/travel/global/exception/CustomExceptionHandler.java
+++ b/travel/src/main/java/com/travel/global/exception/CustomExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.travel.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<String> customExceptionHandler(CustomException e) {
+        return ResponseEntity.status(e.getCustomExceptionType().getHttpStatus())
+                .body(e.getCustomExceptionType().getErrorMsg());
+    }
+}

--- a/travel/src/main/java/com/travel/global/exception/CustomExceptionType.java
+++ b/travel/src/main/java/com/travel/global/exception/CustomExceptionType.java
@@ -1,0 +1,9 @@
+package com.travel.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface CustomExceptionType {
+
+    HttpStatus getHttpStatus();
+    String getErrorMsg();
+}

--- a/travel/src/main/java/com/travel/member/entity/Hobby.java
+++ b/travel/src/main/java/com/travel/member/entity/Hobby.java
@@ -9,9 +9,9 @@ public enum Hobby {
     TREKKING("트레킹");
 
 
-    String name;
+    String korean;
 
-    Hobby(String name) {
-        this.name = name;
+    Hobby(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/order/entity/Order.java
+++ b/travel/src/main/java/com/travel/order/entity/Order.java
@@ -29,6 +29,6 @@ public class Order extends BaseEntityWithModifiedDate {
     @Column(name = "is_canceled")
     private Boolean isCanceled;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "order", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<PurchasedProduct> purchasedProducts = new ArrayList<>();
 }

--- a/travel/src/main/java/com/travel/product/entity/CategoryEnum.java
+++ b/travel/src/main/java/com/travel/product/entity/CategoryEnum.java
@@ -1,0 +1,19 @@
+package com.travel.product.entity;
+
+public enum CategoryEnum {
+    GROUP("그룹별 여행"),
+    WITH_FIFTYSEVNETY("5070끼리"), WITH_MALE("남자끼리"), WITH_FEMALE("여자끼리"),
+    WITH_FAMILY("가족끼리"), ANYONE("누구든지"),
+    LOCATION("지역별 여행"),
+    AMERICA("아메리카"), ASIA("아시아"), AFRICA("아프리카"),
+    OCEANIA("오세아니아"), EUROPE("유럽"),
+    THEME("테마별 여행"),
+    CULTURAL("문화탐방"), GOLF("골프여행"), VACATION("휴양지"),
+    TREKKING("트레킹"), PILGRIMAGE("성지순례"), VOLUNTOUR("볼룬투어");
+
+    String korean;
+
+    CategoryEnum(String korean) {
+        this.korean = korean;
+    }
+}

--- a/travel/src/main/java/com/travel/product/entity/Status.java
+++ b/travel/src/main/java/com/travel/product/entity/Status.java
@@ -7,9 +7,13 @@ public enum Status {
     HIDDEN("숨김");
 
 
-    private String name;
+    private String korean;
 
-    Status(String name) {
-        this.name = name;
+    public String getKorean() {
+        return korean;
+    }
+
+    Status(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/product/exception/ProductException.java
+++ b/travel/src/main/java/com/travel/product/exception/ProductException.java
@@ -1,0 +1,17 @@
+package com.travel.product.exception;
+
+import com.travel.global.exception.CustomException;
+import com.travel.global.exception.CustomExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ProductException extends CustomException {
+
+    private final ProductExceptionType productExceptionType;
+
+
+    @Override
+    public CustomExceptionType getCustomExceptionType() {
+        return productExceptionType;
+    }
+}

--- a/travel/src/main/java/com/travel/product/exception/ProductExceptionType.java
+++ b/travel/src/main/java/com/travel/product/exception/ProductExceptionType.java
@@ -1,0 +1,23 @@
+package com.travel.product.exception;
+
+import com.travel.global.exception.CustomExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ProductExceptionType implements CustomExceptionType {
+
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMsg;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+    @Override
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+}

--- a/travel/src/main/java/com/travel/survey/entity/Gender.java
+++ b/travel/src/main/java/com/travel/survey/entity/Gender.java
@@ -5,9 +5,9 @@ public enum Gender {
     MALE("남자"),
     FEMALE("여자");
 
-    String name;
+    String korean;
 
-    Gender(String name) {
-        this.name = name;
+    Gender(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Group.java
+++ b/travel/src/main/java/com/travel/survey/entity/Group.java
@@ -10,9 +10,9 @@ public enum Group {
     SEVENTY("70대");
 
 
-    String name;
+    String korean;
 
-    Group(String name) {
-        this.name = name;
+    Group(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Partner.java
+++ b/travel/src/main/java/com/travel/survey/entity/Partner.java
@@ -8,9 +8,9 @@ public enum Partner {
     FAMILY("가족");
 
 
-    String name;
+    String korean;
 
-    Partner(String name) {
-        this.name = name;
+    Partner(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Religion.java
+++ b/travel/src/main/java/com/travel/survey/entity/Religion.java
@@ -9,9 +9,9 @@ public enum Religion {
     JUDAISM("유대교"),
     ATHEISM("무교");
 
-    String name;
+    String korean;
 
-    Religion(String name) {
-        this.name = name;
+    Religion(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Season.java
+++ b/travel/src/main/java/com/travel/survey/entity/Season.java
@@ -6,9 +6,9 @@ public enum Season {
     GOLF("가을"),
     WINE("겨울");
 
-    String name;
+    String korean;
 
-    Season(String name) {
-        this.name = name;
+    Season(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Theme.java
+++ b/travel/src/main/java/com/travel/survey/entity/Theme.java
@@ -11,9 +11,9 @@ public enum Theme {
     VOLUNTEER("봉사활동"),
     TREKKING("트레킹");
 
-    String name;
+    String korean;
 
-    Theme(String name) {
-        this.name = name;
+    Theme(String korean) {
+        this.korean = korean;
     }
 }


### PR DESCRIPTION
## Motivation

https://github.com/KDT3-Final-6/final-project-BE/issues/11
위의 이슈에 직접적으로 관련된 모든 활동
+
사소한 리팩토링

## Key Changes
- Change 1
- https://github.com/KDT3-Final-6/final-project-BE/issues/11
    - 0217ae3a : global.exception 패키지 생성 후 http상태코드와 에러메시지를 관리하는 CustomExceptionType 인터페이스 생성, RuntimeException을 상속받고 CustomExceptionType을 관리하는 CustomException 생성, CustomExceptionHandler 구현
    - 07729658 : Product의 모든 예외처리를 담당하는 ProductExcpetion 생성
- Change 2
- 사소한 리팩토링들
  -  81670f87 : Enum 타입들 안의 String name -> String korean으로 rename. String으로 바꿔주는 enum.name()과 명확한 구분을 위하여
  - e66208e5 : Category의 Entity 승격에 따른 Category Entity 에 들어갈 CategoryEnum 생성. 카테고리는 정해진 값이므로 enum으로 두고 관리 하기 위하여 
  - efef709e : OneToMany의 default fetch type이 lazy이므로 기존에 들어간 FetchType.Lazy들 삭제 

## To reviewers

앞으로는 OneToMany에서는 FetchType을 생략

