### PR TITLE
Feature/product 상품과 관련된 Post 기능 구현

### DIFF
--- a/travel/src/main/java/com/travel/admin/controller/AdminController.java
+++ b/travel/src/main/java/com/travel/admin/controller/AdminController.java
@@ -1,4 +1,33 @@
 package com.travel.admin.controller;
 
+import com.travel.product.dto.PeriodPostRequestDTO;
+import com.travel.product.dto.ProductPostRequestDTO;
+import com.travel.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admins")
 public class AdminController {
+
+    private final ProductService productService;
+
+    @PostMapping("/products")
+    public ResponseEntity<String> postProduct(@RequestBody @Valid ProductPostRequestDTO productPostRequestDTO) {
+        productService.createProduct(productPostRequestDTO);
+        return ResponseEntity.ok(null);
+    }
+
+    @PostMapping("/products/periods")
+    public ResponseEntity postPeriod(@RequestBody @Valid PeriodPostRequestDTO periodPostRequestDTO) {
+        productService.createPeriodOptions(periodPostRequestDTO);
+        return ResponseEntity.ok(null);
+    }
 }

--- a/travel/src/main/java/com/travel/global/exception/CustomException.java
+++ b/travel/src/main/java/com/travel/global/exception/CustomException.java
@@ -1,0 +1,7 @@
+package com.travel.global.exception;
+
+public abstract class CustomException extends RuntimeException{
+
+    public abstract CustomExceptionType getCustomExceptionType();
+
+}

--- a/travel/src/main/java/com/travel/global/exception/CustomExceptionHandler.java
+++ b/travel/src/main/java/com/travel/global/exception/CustomExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.travel.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<String> customExceptionHandler(CustomException e) {
+        return ResponseEntity.status(e.getCustomExceptionType().getHttpStatus())
+                .body(e.getCustomExceptionType().getErrorMsg());
+    }
+}

--- a/travel/src/main/java/com/travel/global/exception/CustomExceptionType.java
+++ b/travel/src/main/java/com/travel/global/exception/CustomExceptionType.java
@@ -1,0 +1,9 @@
+package com.travel.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface CustomExceptionType {
+
+    HttpStatus getHttpStatus();
+    String getErrorMsg();
+}

--- a/travel/src/main/java/com/travel/member/entity/Hobby.java
+++ b/travel/src/main/java/com/travel/member/entity/Hobby.java
@@ -9,9 +9,9 @@ public enum Hobby {
     TREKKING("트레킹");
 
 
-    String name;
+    String korean;
 
-    Hobby(String name) {
-        this.name = name;
+    Hobby(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/order/entity/Order.java
+++ b/travel/src/main/java/com/travel/order/entity/Order.java
@@ -29,6 +29,6 @@ public class Order extends BaseEntityWithModifiedDate {
     @Column(name = "is_canceled")
     private Boolean isCanceled;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "order", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<PurchasedProduct> purchasedProducts = new ArrayList<>();
 }

--- a/travel/src/main/java/com/travel/product/dto/PeriodOptionDTO.java
+++ b/travel/src/main/java/com/travel/product/dto/PeriodOptionDTO.java
@@ -1,0 +1,40 @@
+package com.travel.product.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.Future;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Positive;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+public class PeriodOptionDTO {
+
+    @NotBlank
+    private String optionName;
+
+    @NotBlank
+    private String periodString;
+
+    @Future
+    private LocalDate startDate;
+
+    @Future
+    private LocalDate endDate;
+
+    @Positive
+    private Integer maximumQuantity;
+
+    @Positive
+    private Integer minimumQuantity;
+
+    public void setDates() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+
+        String[] parts = periodString.split(" ");
+
+        startDate = LocalDate.parse(parts[0], formatter);
+        endDate = LocalDate.parse(parts[2], formatter);
+    }
+}

--- a/travel/src/main/java/com/travel/product/dto/PeriodPostRequestDTO.java
+++ b/travel/src/main/java/com/travel/product/dto/PeriodPostRequestDTO.java
@@ -1,0 +1,48 @@
+package com.travel.product.dto;
+
+import com.travel.product.entity.PeriodOption;
+import lombok.Getter;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Getter
+public class PeriodPostRequestDTO {
+    private Long productId;
+
+    @Valid
+    private List<PeriodOptionDTO> options = new ArrayList<>();
+
+    public List<PeriodOption> toEntities() {
+
+//        List<PeriodOption> periodOptionList = new ArrayList<>();
+//        for(PeriodOptionPostRequestDTO periodOption : periodOptions){
+//            periodOption.setDates();
+//            //request로 받은걸 파싱해서 Date에 다시 넣는용도
+//            periodOptionList.add(
+//                    PeriodOption.builder()
+//                            .startDate(periodOption.getStartDate())
+//                            .endDate(periodOption.getEndDate())
+//                            .maximumQuantity(periodOption.getMaximumQuantity())
+//                            .minimumQuantity(periodOption.getMinimumQuantity())
+//                            .build()
+//            );
+//        }
+
+        List<PeriodOption> periodOptionList = options.stream()
+                .peek(PeriodOptionDTO::setDates)
+                .map(periodOption -> PeriodOption.builder()
+                        .optionName(periodOption.getOptionName())
+                        .startDate(periodOption.getStartDate())
+                        .endDate(periodOption.getEndDate())
+                        .maximumQuantity(periodOption.getMaximumQuantity())
+                        .minimumQuantity(periodOption.getMinimumQuantity())
+                        .build())
+                .collect(toList());
+
+        return periodOptionList;
+    }
+}

--- a/travel/src/main/java/com/travel/product/dto/ProductPostRequestDTO.java
+++ b/travel/src/main/java/com/travel/product/dto/ProductPostRequestDTO.java
@@ -1,0 +1,56 @@
+package com.travel.product.dto;
+
+import com.travel.product.entity.Product;
+import com.travel.product.entity.Status;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Positive;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ProductPostRequestDTO {
+
+    @NotBlank
+    private String productName;
+
+    @NotBlank
+    private String productThumbnail;
+
+    @Positive
+    private Integer productPrice;
+
+    @NotBlank
+    private String productStatus;
+
+    @NotBlank
+    private String productContent;
+
+    @NotBlank
+    private String contentDetail;
+
+    private List<Long> CategoryIds = new ArrayList<>();
+
+    public Status setEnumProductStatus(String productStatus) {
+        if (productStatus.equals(Status.FORSALE.getKorean())) {
+            return Status.FORSALE;
+        } else if (productStatus.equals(Status.SOLDOUT.getKorean())) {
+            return Status.SOLDOUT;
+        }
+        return Status.HIDDEN;
+    }
+
+    public Product toEntity() {
+        return Product.builder()
+                .productName(productName)
+                .productThumbnail(productThumbnail)
+                .productPrice(productPrice)
+                .productStatus(setEnumProductStatus(productStatus))
+                .productContent(productContent)
+                .contentDetail(contentDetail)
+                .build();
+    }
+
+
+}

--- a/travel/src/main/java/com/travel/product/entity/Category.java
+++ b/travel/src/main/java/com/travel/product/entity/Category.java
@@ -1,12 +1,49 @@
 package com.travel.product.entity;
 
-public enum Category {
-    VACATION("휴양지"),
-    GOLF("골프");
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-    String name;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
-    Category(String name) {
-        this.name = name;
+import static javax.persistence.FetchType.LAZY;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "category")
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long categoryId;
+
+    @OneToMany(mappedBy = "category")
+    private List<ProductCategory> productCategories = new ArrayList<>();
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "parent_id")
+    private Category parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Category> child = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    private CategoryEnum categoryEnum;
+
+    public void setParent(Category parent) {
+        this.parent = parent;
+    }
+
+    public void addChildCategory(Category child) {
+        this.child.add(child);
+        child.setParent(this);
+    }
+
+    public Category(CategoryEnum categoryEnum) {
+        this.categoryEnum = categoryEnum;
     }
 }

--- a/travel/src/main/java/com/travel/product/entity/CategoryEnum.java
+++ b/travel/src/main/java/com/travel/product/entity/CategoryEnum.java
@@ -1,0 +1,19 @@
+package com.travel.product.entity;
+
+public enum CategoryEnum {
+    GROUP("그룹별 여행"),
+    WITH_FIFTYSEVNETY("5070끼리"), WITH_MALE("남자끼리"), WITH_FEMALE("여자끼리"),
+    WITH_FAMILY("가족끼리"), ANYONE("누구든지"),
+    LOCATION("지역별 여행"),
+    AMERICA("아메리카"), ASIA("아시아"), AFRICA("아프리카"),
+    OCEANIA("오세아니아"), EUROPE("유럽"),
+    THEME("테마별 여행"),
+    CULTURAL("문화탐방"), GOLF("골프여행"), VACATION("휴양지"),
+    TREKKING("트레킹"), PILGRIMAGE("성지순례"), VOLUNTOUR("볼룬투어");
+
+    String korean;
+
+    CategoryEnum(String korean) {
+        this.korean = korean;
+    }
+}

--- a/travel/src/main/java/com/travel/product/entity/PeriodOption.java
+++ b/travel/src/main/java/com/travel/product/entity/PeriodOption.java
@@ -24,6 +24,9 @@ public class PeriodOption {
     @JoinColumn(name = "product_id")
     private Product product;
 
+    @Column(name = "option_name")
+    private String optionName;
+
     @Column(name = "start_date")
     private LocalDate startDate;
 
@@ -34,25 +37,30 @@ public class PeriodOption {
     private Integer period;
 
     //최대 인원
-    @Column(name = "period_option_maximum_quantity")
-    private Integer periodOptionMaximumQuantity;
+    @Column(name = "maximum_quantity")
+    private Integer maximumQuantity;
 
     //최소 인원
-    @Column(name = "period_option_minimum_quantity")
-    private Integer periodOptionMinimumQuantity;
+    @Column(name = "minimum_quantity")
+    private Integer minimumQuantity;
 
     //현재 신청한 인원
-    @Column(name = "period_option_sold_quantity")
-    private Integer periodOptionSoldQuantity;
+    @Column(name = "sold_quantity")
+    private Integer soldQuantity;
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
 
     @Builder
-    public PeriodOption(Product product, LocalDate startDate, LocalDate endDate, Integer periodOptionMaximumQuantity, Integer periodOptionMinimumQuantity, Integer periodOptionSoldQuantity) {
+    public PeriodOption(Product product, String optionName, LocalDate startDate, LocalDate endDate, Integer maximumQuantity, Integer minimumQuantity) {
         this.product = product;
+        this.optionName = optionName;
         this.startDate = startDate;
         this.endDate = endDate;
         this.period = Period.between(startDate, endDate).getDays() + 1;
-        this.periodOptionMaximumQuantity = periodOptionMaximumQuantity;
-        this.periodOptionMinimumQuantity = periodOptionMinimumQuantity;
-        this.periodOptionSoldQuantity = periodOptionSoldQuantity;
+        this.maximumQuantity = maximumQuantity;
+        this.minimumQuantity = minimumQuantity;
+        this.soldQuantity = 0;
     }
 }

--- a/travel/src/main/java/com/travel/product/entity/Product.java
+++ b/travel/src/main/java/com/travel/product/entity/Product.java
@@ -27,34 +27,45 @@ public class Product extends BaseEntity {
     @Column(name = "product_thumbnail")
     private String productThumbnail;
 
-    @Column(name = "product_price")
-    private Integer productPrice;
-
-    @Column(name = "product_category")
-    @Enumerated(EnumType.STRING)
-    private Category productCategory;
-
-    @Column(name = "product_status")
-    @Enumerated(EnumType.STRING)
-    private Status productStatus;
-
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "product", cascade = CascadeType.ALL)
-    private List<PeriodOption> periodOptions = new ArrayList<>();
-
-    @Column(name = "product_detail")
-    private String productDetail;
-
-    @Builder
-    public Product(String productName, String productThumbnail, Integer productPrice, Category productCategory, String productDetail) {
-        this.productName = productName;
-        this.productThumbnail = productThumbnail;
-        this.productPrice = productPrice;
-        this.productCategory = productCategory;
-        this.productDetail = productDetail;
-    }
     /*
     @ElementCollection
     @CollectionTable(name = "image")
     private List<String> images = new ArrayList<>();
     */
+
+    @Column(name = "product_price")
+    private Integer productPrice;
+
+    @Column(name = "product_status")
+    @Enumerated(EnumType.STRING)
+    private Status productStatus;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
+    private List<PeriodOption> periodOptions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "product")
+    private List<ProductCategory> productCategories = new ArrayList<>();
+
+    //제목
+    @Column(name = "product_content")
+    private String productContent;
+
+    //상세
+    @Column(name = "content_detail")
+    private String contentDetail;
+
+    public void addPeriodOption(PeriodOption periodOption) {
+        periodOption.setProduct(this);
+        periodOptions.add(periodOption);
+    }
+
+    @Builder
+    public Product(String productName, String productThumbnail, Integer productPrice, Status productStatus, String productContent, String contentDetail) {
+        this.productName = productName;
+        this.productThumbnail = productThumbnail;
+        this.productPrice = productPrice;
+        this.productStatus = productStatus;
+        this.productContent = productContent;
+        this.contentDetail = contentDetail;
+    }
 }

--- a/travel/src/main/java/com/travel/product/entity/ProductCategory.java
+++ b/travel/src/main/java/com/travel/product/entity/ProductCategory.java
@@ -1,0 +1,34 @@
+package com.travel.product.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "product_category")
+public class ProductCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_category_id")
+    private Long productCategoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    public ProductCategory(Product product, Category category) {
+        this.product = product;
+        this.category = category;
+        product.getProductCategories().add(this);
+        category.getProductCategories().add(this);
+    }
+}

--- a/travel/src/main/java/com/travel/product/entity/Status.java
+++ b/travel/src/main/java/com/travel/product/entity/Status.java
@@ -7,9 +7,13 @@ public enum Status {
     HIDDEN("숨김");
 
 
-    private String name;
+    private String korean;
 
-    Status(String name) {
-        this.name = name;
+    public String getKorean() {
+        return korean;
+    }
+
+    Status(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/product/exception/ProductException.java
+++ b/travel/src/main/java/com/travel/product/exception/ProductException.java
@@ -1,0 +1,17 @@
+package com.travel.product.exception;
+
+import com.travel.global.exception.CustomException;
+import com.travel.global.exception.CustomExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ProductException extends CustomException {
+
+    private final ProductExceptionType productExceptionType;
+
+
+    @Override
+    public CustomExceptionType getCustomExceptionType() {
+        return productExceptionType;
+    }
+}

--- a/travel/src/main/java/com/travel/product/exception/ProductExceptionType.java
+++ b/travel/src/main/java/com/travel/product/exception/ProductExceptionType.java
@@ -1,0 +1,23 @@
+package com.travel.product.exception;
+
+import com.travel.global.exception.CustomExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ProductExceptionType implements CustomExceptionType {
+
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMsg;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+    @Override
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+}

--- a/travel/src/main/java/com/travel/product/repository/CategoryRepository.java
+++ b/travel/src/main/java/com/travel/product/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.travel.product.repository;
+
+import com.travel.product.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/travel/src/main/java/com/travel/product/repository/PeriodOptionRepository.java
+++ b/travel/src/main/java/com/travel/product/repository/PeriodOptionRepository.java
@@ -1,0 +1,8 @@
+package com.travel.product.repository;
+
+import com.travel.product.entity.PeriodOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PeriodOptionRepository extends JpaRepository<PeriodOption, Long> {
+
+}

--- a/travel/src/main/java/com/travel/product/repository/ProductCategoryRepository.java
+++ b/travel/src/main/java/com/travel/product/repository/ProductCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.travel.product.repository;
+
+import com.travel.product.entity.ProductCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductCategoryRepository extends JpaRepository<ProductCategory, Long> {
+}

--- a/travel/src/main/java/com/travel/product/repository/ProductRepository.java
+++ b/travel/src/main/java/com/travel/product/repository/ProductRepository.java
@@ -1,0 +1,11 @@
+package com.travel.product.repository;
+
+import com.travel.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+
+}

--- a/travel/src/main/java/com/travel/product/repository/PurchasedProductRepository.java
+++ b/travel/src/main/java/com/travel/product/repository/PurchasedProductRepository.java
@@ -1,0 +1,7 @@
+package com.travel.product.repository;
+
+import com.travel.product.entity.PurchasedProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PurchasedProductRepository extends JpaRepository<PurchasedProduct, Long> {
+}

--- a/travel/src/main/java/com/travel/product/service/ProductService.java
+++ b/travel/src/main/java/com/travel/product/service/ProductService.java
@@ -1,0 +1,81 @@
+package com.travel.product.service;
+
+import com.travel.product.dto.PeriodPostRequestDTO;
+import com.travel.product.dto.ProductPostRequestDTO;
+import com.travel.product.entity.Category;
+import com.travel.product.entity.PeriodOption;
+import com.travel.product.entity.Product;
+import com.travel.product.entity.ProductCategory;
+import com.travel.product.exception.ProductException;
+import com.travel.product.exception.ProductExceptionType;
+import com.travel.product.repository.CategoryRepository;
+import com.travel.product.repository.PeriodOptionRepository;
+import com.travel.product.repository.ProductCategoryRepository;
+import com.travel.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final PeriodOptionRepository periodOptionRepository;
+    private final ProductCategoryRepository productCategoryRepository;
+    private final CategoryRepository categoryRepository;
+
+
+    @Transactional
+    public void createProduct(ProductPostRequestDTO productPostRequestDTO) {
+        Product product = productRepository.save(productPostRequestDTO.toEntity());
+        List<Category> categories = categoryRepository.findAllById(productPostRequestDTO.getCategoryIds());
+
+        /*
+        스트림으로 변환 전 코드
+
+        List<ProductCategory> productCategories = new ArrayList<>();
+        for (int i = 0; i < productPostRequestDTO.getCategoryIds().size(); i++) {
+            productCategories.add(new ProductCategory(product, categories.get(i)));
+        }
+         */
+
+        List<ProductCategory> productCategories = IntStream.range(0, categories.size())
+                .mapToObj(i -> new ProductCategory(product, categories.get(i)))
+                .collect(toList());
+
+        productCategoryRepository.saveAll(productCategories);
+    }
+
+    @Transactional
+    public void createPeriodOptions(PeriodPostRequestDTO periodPostRequestDTO) {
+
+//        Product product = productRepository.findById(periodPostRequestDTO.getProductId())
+//                .orElseThrow(()->new ProductException(ProductExceptionType.PRODUCT_NOT_FOUND));
+
+        Product product = productRepository.findById(periodPostRequestDTO.getProductId())
+                .orElseThrow(() -> {
+                    ProductExceptionType exceptionType = ProductExceptionType.PRODUCT_NOT_FOUND;
+                    log.error(exceptionType.getErrorMsg());
+                    return new ProductException(exceptionType);
+                });
+
+        List<PeriodOption> periodOptionList = periodPostRequestDTO.toEntities();
+
+        /*
+        for (PeriodOption periodOption : periodOptionList) {
+            product.addPeriodOption(periodOption);
+        }
+        */
+
+        periodOptionList.forEach(product::addPeriodOption);
+    }
+}

--- a/travel/src/main/java/com/travel/survey/entity/Gender.java
+++ b/travel/src/main/java/com/travel/survey/entity/Gender.java
@@ -5,9 +5,9 @@ public enum Gender {
     MALE("남자"),
     FEMALE("여자");
 
-    String name;
+    String korean;
 
-    Gender(String name) {
-        this.name = name;
+    Gender(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Group.java
+++ b/travel/src/main/java/com/travel/survey/entity/Group.java
@@ -10,9 +10,9 @@ public enum Group {
     SEVENTY("70대");
 
 
-    String name;
+    String korean;
 
-    Group(String name) {
-        this.name = name;
+    Group(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Partner.java
+++ b/travel/src/main/java/com/travel/survey/entity/Partner.java
@@ -8,9 +8,9 @@ public enum Partner {
     FAMILY("가족");
 
 
-    String name;
+    String korean;
 
-    Partner(String name) {
-        this.name = name;
+    Partner(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Religion.java
+++ b/travel/src/main/java/com/travel/survey/entity/Religion.java
@@ -9,9 +9,9 @@ public enum Religion {
     JUDAISM("유대교"),
     ATHEISM("무교");
 
-    String name;
+    String korean;
 
-    Religion(String name) {
-        this.name = name;
+    Religion(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Season.java
+++ b/travel/src/main/java/com/travel/survey/entity/Season.java
@@ -6,9 +6,9 @@ public enum Season {
     GOLF("가을"),
     WINE("겨울");
 
-    String name;
+    String korean;
 
-    Season(String name) {
-        this.name = name;
+    Season(String korean) {
+        this.korean = korean;
     }
 }

--- a/travel/src/main/java/com/travel/survey/entity/Theme.java
+++ b/travel/src/main/java/com/travel/survey/entity/Theme.java
@@ -11,9 +11,9 @@ public enum Theme {
     VOLUNTEER("봉사활동"),
     TREKKING("트레킹");
 
-    String name;
+    String korean;
 
-    Theme(String name) {
-        this.name = name;
+    Theme(String korean) {
+        this.korean = korean;
     }
 }


### PR DESCRIPTION
## Motivation

https://github.com/KDT3-Final-6/final-project-BE/issues/8
위의 이슈에서
 POST /admins/products (카테고리는 기존에 존재하고 그 카테고리 중에서)
 POST /admins/products/periods (상품을 먼저 생성하고 그 상품의 옵션을 추가하는 식)
구현

## Key Changes

- Change 1
- 공통사항
  - f58c9d73 : Product와 연관된 Entity들의 Repository 생성
  - fc8a27b7, 5ca7aeda : Product <-> ProductCategory <-> Category 다대다 양방향 매핑을 위한 중간 테이블(ProductCategory)  생성 및 양방향 매핑, 연관관계 메소드들 추가
  - d935a359 : Product, PeriodOption의 연관관계 및 설계에 따른 완성도를 높이기 위한 리팩토링
- Change 2
- POST /admins/products, POST /admins/products/periods
  - f9b87e49 : RequestBody로 생성할 Product의 정보를 받기 위한 DTO 생성
  - 238bbb0a : RequestBody로 생성할 PeriodOption의 정보를 받기 위한 DTO 생성
  - 25babefe : Product, PeriodOption create에 필요한 메소드들 ProductService에 구현
  - a40314c8 : Product, PeriodOption 생성은 관리자의 역할이므로 AdminController의 PostMapping에 service에서 구현한 로직들 연결

## To reviewers

