### PR TITLE
Feature/order 상품 구매 기능 구현

### DIFF
--- a/travel/src/main/java/com/travel/member/repository/MemberRepository.java
+++ b/travel/src/main/java/com/travel/member/repository/MemberRepository.java
@@ -4,7 +4,10 @@ import com.travel.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByMemberEmail(String email);
 }

--- a/travel/src/main/java/com/travel/member/repository/MemberRepository.java
+++ b/travel/src/main/java/com/travel/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.travel.member.repository;
+
+import com.travel.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/travel/src/main/java/com/travel/order/controller/OrderController.java
+++ b/travel/src/main/java/com/travel/order/controller/OrderController.java
@@ -1,10 +1,28 @@
 package com.travel.order.controller;
 
+import com.travel.order.dto.request.OrderCreateListDTO;
+import com.travel.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
+
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/orders")
 public class OrderController {
 
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<String> createOrder(@Valid @RequestBody OrderCreateListDTO orderCreateListDTO) {
+        String userEmail = "test@test.com";
+        orderService.createOrder(orderCreateListDTO, userEmail);
+
+        return ResponseEntity.ok(null);
+    }
 }

--- a/travel/src/main/java/com/travel/order/controller/OrderController.java
+++ b/travel/src/main/java/com/travel/order/controller/OrderController.java
@@ -1,0 +1,10 @@
+package com.travel.order.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/orders")
+public class OrderController {
+
+}

--- a/travel/src/main/java/com/travel/order/dto/request/OrderCreateDTO.java
+++ b/travel/src/main/java/com/travel/order/dto/request/OrderCreateDTO.java
@@ -1,0 +1,18 @@
+package com.travel.order.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Setter
+@Getter
+public class OrderCreateDTO {
+
+    @NotNull
+    private Long productId;
+
+    @NotNull
+    private Long periodOptionId;
+
+}

--- a/travel/src/main/java/com/travel/order/dto/request/OrderCreateListDTO.java
+++ b/travel/src/main/java/com/travel/order/dto/request/OrderCreateListDTO.java
@@ -1,0 +1,17 @@
+package com.travel.order.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Setter
+@Getter
+public class OrderCreateListDTO {
+
+    @NotNull
+    @Valid
+    private List<OrderCreateDTO> productIds;
+}

--- a/travel/src/main/java/com/travel/order/entity/Order.java
+++ b/travel/src/main/java/com/travel/order/entity/Order.java
@@ -36,6 +36,7 @@ public class Order extends BaseEntityWithModifiedDate {
     @Builder
     public Order(Member member, List<PurchasedProduct> purchasedProducts) {
         this.member = member;
+        this.isCanceled = false;
         this.purchasedProducts = purchasedProducts;
     }
 

--- a/travel/src/main/java/com/travel/order/entity/Order.java
+++ b/travel/src/main/java/com/travel/order/entity/Order.java
@@ -4,6 +4,7 @@ import com.travel.global.entity.BaseEntityWithModifiedDate;
 import com.travel.member.entity.Member;
 import com.travel.product.entity.PurchasedProduct;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,4 +32,11 @@ public class Order extends BaseEntityWithModifiedDate {
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<PurchasedProduct> purchasedProducts = new ArrayList<>();
+
+    @Builder
+    public Order(Member member, List<PurchasedProduct> purchasedProducts) {
+        this.member = member;
+        this.purchasedProducts = purchasedProducts;
+    }
+
 }

--- a/travel/src/main/java/com/travel/order/exception/OrderException.java
+++ b/travel/src/main/java/com/travel/order/exception/OrderException.java
@@ -1,0 +1,17 @@
+package com.travel.order.exception;
+
+import com.travel.global.exception.CustomException;
+import com.travel.global.exception.CustomExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OrderException extends CustomException {
+
+    private final OrderExceptionType productExceptionType;
+
+
+    @Override
+    public CustomExceptionType getCustomExceptionType() {
+        return productExceptionType;
+    }
+}

--- a/travel/src/main/java/com/travel/order/exception/OrderExceptionType.java
+++ b/travel/src/main/java/com/travel/order/exception/OrderExceptionType.java
@@ -1,14 +1,13 @@
-package com.travel.product.exception;
+package com.travel.order.exception;
 
 import com.travel.global.exception.CustomExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
-public enum ProductExceptionType implements CustomExceptionType {
+public enum OrderExceptionType implements CustomExceptionType {
 
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
-    PERIOD_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 기간 옵션입니다.");
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."); //임시로 넣어둠 나중에 바꿀거임
 
     private final HttpStatus httpStatus;
     private final String errorMsg;

--- a/travel/src/main/java/com/travel/order/repository/OrderRepository.java
+++ b/travel/src/main/java/com/travel/order/repository/OrderRepository.java
@@ -1,0 +1,13 @@
+package com.travel.order.repository;
+
+import com.travel.member.entity.Member;
+import com.travel.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+}

--- a/travel/src/main/java/com/travel/order/service/OrderService.java
+++ b/travel/src/main/java/com/travel/order/service/OrderService.java
@@ -1,6 +1,9 @@
 package com.travel.order.service;
 
+import com.travel.order.dto.request.OrderCreateListDTO;
+
 public interface OrderService {
 
+    void createOrder(OrderCreateListDTO orderCreateListDTO, String userEmail);
 
 }

--- a/travel/src/main/java/com/travel/order/service/OrderService.java
+++ b/travel/src/main/java/com/travel/order/service/OrderService.java
@@ -1,0 +1,6 @@
+package com.travel.order.service;
+
+public interface OrderService {
+
+
+}

--- a/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
+++ b/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
@@ -1,0 +1,9 @@
+package com.travel.order.service.impl;
+
+import com.travel.order.service.OrderService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderServiceImpl implements OrderService {
+
+}

--- a/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
+++ b/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
@@ -1,9 +1,67 @@
 package com.travel.order.service.impl;
 
+import com.travel.member.entity.Member;
+import com.travel.member.repository.MemberRepository;
+import com.travel.order.dto.request.OrderCreateDTO;
+import com.travel.order.dto.request.OrderCreateListDTO;
+import com.travel.order.entity.Order;
+import com.travel.order.repository.OrderRepository;
 import com.travel.order.service.OrderService;
+import com.travel.product.entity.PeriodOption;
+import com.travel.product.entity.Product;
+import com.travel.product.entity.PurchasedProduct;
+import com.travel.product.repository.PeriodOptionRepository;
+import com.travel.product.repository.ProductRepository;
+import com.travel.product.repository.PurchasedProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 
+    private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+    private final PurchasedProductRepository purchasedProductRepository;
+    private final PeriodOptionRepository periodOptionRepository;
+
+    @Override
+    public void createOrder(OrderCreateListDTO orderCreateListDTO, String userEmail) {
+        Member member = memberRepository.findByMemberEmail(userEmail)
+                .orElseThrow(() -> null); //나중에 예외처리 하기
+
+        List<OrderCreateDTO> createList = orderCreateListDTO.getProductIds();
+
+        List<PurchasedProduct> purchasedProductList = createList.stream()
+                .map(createDTO -> {
+                    Product product = productRepository.findById(createDTO.getProductId())
+                            .orElseThrow(() -> null);
+                    PeriodOption periodOption = periodOptionRepository.findById(createDTO.getPeriodOptionId())
+                            .orElseThrow(() -> null);
+
+                    Integer periodOptionSoldQuantity = periodOption.getPeriodOptionSoldQuantity();
+                    periodOption.setPeriodOptionSoldQuantity(periodOptionSoldQuantity + 1);
+                    periodOptionRepository.save(periodOption);
+
+                    return product.toPurchase(periodOption);
+                })
+                .collect(Collectors.toList());
+
+        Order order = Order.builder()
+                .member(member)
+                .purchasedProducts(purchasedProductList)
+                .build();
+
+        purchasedProductList.forEach(purchasedProduct -> purchasedProduct.setOrder(order));
+
+        orderRepository.save(order);
+    }
 }

--- a/travel/src/main/java/com/travel/product/entity/PeriodOption.java
+++ b/travel/src/main/java/com/travel/product/entity/PeriodOption.java
@@ -63,4 +63,8 @@ public class PeriodOption {
         this.minimumQuantity = minimumQuantity;
         this.soldQuantity = 0;
     }
+
+    public void setPeriodOptionSoldQuantity(Integer periodOptionSoldQuantity) {
+        this.periodOptionSoldQuantity = periodOptionSoldQuantity;
+    }
 }

--- a/travel/src/main/java/com/travel/product/entity/PeriodOption.java
+++ b/travel/src/main/java/com/travel/product/entity/PeriodOption.java
@@ -64,7 +64,7 @@ public class PeriodOption {
         this.soldQuantity = 0;
     }
 
-    public void setPeriodOptionSoldQuantity(Integer periodOptionSoldQuantity) {
-        this.periodOptionSoldQuantity = periodOptionSoldQuantity;
+    public void setSoldQuantity(Integer soldQuantity) {
+        this.soldQuantity = soldQuantity;
     }
 }

--- a/travel/src/main/java/com/travel/product/entity/Product.java
+++ b/travel/src/main/java/com/travel/product/entity/Product.java
@@ -27,20 +27,18 @@ public class Product extends BaseEntity {
     @Column(name = "product_thumbnail")
     private String productThumbnail;
 
-    /*
-    @ElementCollection
-    @CollectionTable(name = "image")
-    private List<String> images = new ArrayList<>();
-    */
-
     @Column(name = "product_price")
     private Integer productPrice;
+
+    @Column(name = "product_category")
+    @Enumerated(EnumType.STRING)
+    private Category productCategory;
 
     @Column(name = "product_status")
     @Enumerated(EnumType.STRING)
     private Status productStatus;
 
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "product", cascade = CascadeType.ALL)
     private List<PeriodOption> periodOptions = new ArrayList<>();
 
     @OneToMany(mappedBy = "product")
@@ -67,5 +65,22 @@ public class Product extends BaseEntity {
         this.productStatus = productStatus;
         this.productContent = productContent;
         this.contentDetail = contentDetail;
+    }
+    /*
+    @ElementCollection
+    @CollectionTable(name = "image")
+    private List<String> images = new ArrayList<>();
+    */
+
+    public PurchasedProduct toPurchase(PeriodOption periodOption) {
+        return PurchasedProduct.builder()
+                .product(this)
+                .purchasedProductName(productName)
+                .purchasedProductThumbnail(productThumbnail)
+                .purchasedProductPrice(productPrice)
+                .startDate(periodOption.getStartDate())
+                .endDate(periodOption.getEndDate())
+                .period(periodOption.getPeriod())
+                .build();
     }
 }

--- a/travel/src/main/java/com/travel/product/entity/Product.java
+++ b/travel/src/main/java/com/travel/product/entity/Product.java
@@ -30,10 +30,6 @@ public class Product extends BaseEntity {
     @Column(name = "product_price")
     private Integer productPrice;
 
-    @Column(name = "product_category")
-    @Enumerated(EnumType.STRING)
-    private Category productCategory;
-
     @Column(name = "product_status")
     @Enumerated(EnumType.STRING)
     private Status productStatus;

--- a/travel/src/main/java/com/travel/product/entity/PurchasedProduct.java
+++ b/travel/src/main/java/com/travel/product/entity/PurchasedProduct.java
@@ -2,6 +2,7 @@ package com.travel.product.entity;
 
 import com.travel.order.entity.Order;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -47,4 +48,8 @@ public class PurchasedProduct {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")
     private Order order;
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
 }

--- a/travel/src/main/java/com/travel/product/repository/PeriodOptionRepository.java
+++ b/travel/src/main/java/com/travel/product/repository/PeriodOptionRepository.java
@@ -2,7 +2,8 @@ package com.travel.product.repository;
 
 import com.travel.product.entity.PeriodOption;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PeriodOptionRepository extends JpaRepository<PeriodOption, Long> {
-
 }

--- a/travel/src/main/java/com/travel/product/repository/ProductRepository.java
+++ b/travel/src/main/java/com/travel/product/repository/ProductRepository.java
@@ -6,6 +6,4 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
-
-
 }

--- a/travel/src/test/java/com/travel/order/controller/OrderControllerTest.java
+++ b/travel/src/test/java/com/travel/order/controller/OrderControllerTest.java
@@ -1,0 +1,73 @@
+package com.travel.order.controller;
+
+import com.travel.order.dto.request.OrderCreateDTO;
+import com.travel.order.dto.request.OrderCreateListDTO;
+import com.travel.order.entity.Order;
+import com.travel.order.repository.OrderRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class OrderControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    OrderRepository orderRepository;
+
+    @AfterEach
+    void clean() {
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("상품 구매 성공")
+    void createOrderSuccess() {
+        //given
+        Long productId = 3L;
+        Long periodOptionId = 2L;
+
+        OrderCreateDTO createDTO1 = new OrderCreateDTO();
+        OrderCreateDTO createDTO2 = new OrderCreateDTO();
+        createDTO1.setProductId(productId);
+        createDTO1.setPeriodOptionId(periodOptionId);
+        createDTO2.setProductId(productId);
+        createDTO2.setPeriodOptionId(periodOptionId);
+
+        List<OrderCreateDTO> createDTOList = new ArrayList<>();
+        createDTOList.add(createDTO1);
+        createDTOList.add(createDTO2);
+
+        OrderCreateListDTO createListDTO = new OrderCreateListDTO();
+        createListDTO.setProductIds(createDTOList);
+
+        String url = "http://localhost:" + port + "/orders";
+
+        //when
+        ResponseEntity<String> responseEntity = restTemplate.postForEntity(url, createListDTO, String.class);
+
+        //then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).isNull();
+
+        List<Order> orderList = orderRepository.findAll();
+        assertThat(orderList.get(0).getIsCanceled()).isFalse();
+        assertThat(orderList.get(0).getMember().getMemberId()).isEqualTo(1L);
+    }
+}

--- a/travel/src/test/java/com/travel/order/controller/OrderControllerTest.java
+++ b/travel/src/test/java/com/travel/order/controller/OrderControllerTest.java
@@ -40,8 +40,8 @@ class OrderControllerTest {
     @DisplayName("상품 구매 성공")
     void createOrderSuccess() {
         //given
-        Long productId = 3L;
-        Long periodOptionId = 2L;
+        Long productId = 1L;
+        Long periodOptionId = 1L;
 
         OrderCreateDTO createDTO1 = new OrderCreateDTO();
         OrderCreateDTO createDTO2 = new OrderCreateDTO();
@@ -69,5 +69,73 @@ class OrderControllerTest {
         List<Order> orderList = orderRepository.findAll();
         assertThat(orderList.get(0).getIsCanceled()).isFalse();
         assertThat(orderList.get(0).getMember().getMemberId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("상품 구매 실패 (없는 상품)")
+    void createOrderFailed1() {
+        //given
+        Long productId = 0L;
+        Long periodOptionId = 1L;
+
+        OrderCreateDTO createDTO1 = new OrderCreateDTO();
+        OrderCreateDTO createDTO2 = new OrderCreateDTO();
+        createDTO1.setProductId(productId);
+        createDTO1.setPeriodOptionId(periodOptionId);
+        createDTO2.setProductId(productId);
+        createDTO2.setPeriodOptionId(periodOptionId);
+
+        List<OrderCreateDTO> createDTOList = new ArrayList<>();
+        createDTOList.add(createDTO1);
+        createDTOList.add(createDTO2);
+
+        OrderCreateListDTO createListDTO = new OrderCreateListDTO();
+        createListDTO.setProductIds(createDTOList);
+
+        String url = "http://localhost:" + port + "/orders";
+
+        //when
+        ResponseEntity<String> responseEntity = restTemplate.postForEntity(url, createListDTO, String.class);
+
+        //then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(responseEntity.getBody()).isEqualTo("존재하지 않는 상품입니다.");
+
+        List<Order> orderList = orderRepository.findAll();
+        assertThat(orderList).isEmpty();
+    }
+
+    @Test
+    @DisplayName("상품 구매 실패 (없는 옵션)")
+    void createOrderFailed2() {
+        //given
+        Long productId = 1L;
+        Long periodOptionId = 0L;
+
+        OrderCreateDTO createDTO1 = new OrderCreateDTO();
+        OrderCreateDTO createDTO2 = new OrderCreateDTO();
+        createDTO1.setProductId(productId);
+        createDTO1.setPeriodOptionId(periodOptionId);
+        createDTO2.setProductId(productId);
+        createDTO2.setPeriodOptionId(periodOptionId);
+
+        List<OrderCreateDTO> createDTOList = new ArrayList<>();
+        createDTOList.add(createDTO1);
+        createDTOList.add(createDTO2);
+
+        OrderCreateListDTO createListDTO = new OrderCreateListDTO();
+        createListDTO.setProductIds(createDTOList);
+
+        String url = "http://localhost:" + port + "/orders";
+
+        //when
+        ResponseEntity<String> responseEntity = restTemplate.postForEntity(url, createListDTO, String.class);
+
+        //then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(responseEntity.getBody()).isEqualTo("존재하지 않는 기간 옵션입니다.");
+
+        List<Order> orderList = orderRepository.findAll();
+        assertThat(orderList).isEmpty();
     }
 }


### PR DESCRIPTION
## Motivation

#9 
상품 구매 기능 구현

## Key Changes

작업한 내용의 주요 변경사항을 자세히 나열하세요

- Change 1
  - 기능 구현에 필요한 Repository 생성 
     - 57a818222c9e4dce34f4456c409bf52e6bf50d44: OrderRepository 생성
     - 13dc09c8420f0caf4b77b36d5b9508bba47c647d: MemberRepository 생성
     - 2d527032363cd2333b2c2d0ba70a8d43cf91736c: ProductRepository 생성
     - e5798bc8a6feb468a87a412023e9d20355875041: PeriodOptionRepository 생성
- Change 2
    - 상품 구매 기능
       - dc48b6d1830237293acecd6f37e852581f755d88: OrderService 생성
       - 51e8edf08fc65a2bac58ddc716ff45d23115c750: OrderController 생성
       - 9b789e1ac607976dcc732d1fbd8b81d03b48ccf4: MemberRepository에 findByMemberEmail 쿼리 메서드 생성
       - 57ac80ab01bfa25a08cff21d9244d5c5c3f6914a: 상품 구매 requestDTO 생성
       - dd893bb458bb8fafcc410af2ab364e57e632d299: OrderController에 상품 구매(createOrder) API 구현
       - 9ff49b28f641afb03cbd598a1aad5caa5793a51c: Product를 PurchasedProduct로 바꾸는 메서드(toPurchase) 생성
       - ad2f3adc92bef05da2ffcd84fef5d80327d87379: Order에 빌더 패턴으로 생성자 생성
       - d575cfa410b9b288f640ec8556e3df1383a184a7: OrderService에 상품 구매(createOrder) 기능 구현
       - d83f6d83004a7242ed005e37b26eddd1853bb211: PeriodOption에 setPeriodOptionSoldQuantity 메서드(setter) 생성
       - d8a9cd936c03bd9b37110eea374309209119d798: PurchasedProduct에 setOrder 메서드(setter) 생성
       - ba0c103d76ba5da03417d1ccb2b9c695abe0d76c: Orders 테이블에 저장 시 isCanceled 필드가 null로 저장되는 문제를 수정
       - 2e06dbcf46e5afa3bca275f8b307becedbd7db6c: 상품 구매 기능 CustomException 생성
       - 
   - 테스트
      - 10d234c56dc7760ef21cbf3ea88313077ccfa7da: 상품 구매 API(POST /orders) 성공 테스트
      - 805e5fcbae14a48c2c6e4e5f7f643306470e5af9: 상품 구매 API(POST /orders) 실패 테스트
 - Change 3
   - 기타
      - 025d02bae8f9f214aae426e2a0848cf0a511f9b2: PeriodOption에 setPeriodOptionSoldQuantity -> setSoldQuantity로 이름 변경 
      - a2dab85d82e350f7de649112d808e5e3235bf926: Product에 Category 필드 제거
    
## To reviewers

기능만 동작하게 만들어서 나중에 리팩터링 할 예정입니다.
