### PR TITLE
Feature/cart 장바구니 상품 삭제, 조회, 수정 기능 구현

### DIFF
--- a/travel/src/main/java/com/travel/cart/controller/CartController.java
+++ b/travel/src/main/java/com/travel/cart/controller/CartController.java
@@ -1,6 +1,7 @@
 package com.travel.cart.controller;
 
-import com.travel.cart.dto.CartAddDTO;
+import com.travel.cart.dto.request.CartAddDTO;
+import com.travel.cart.dto.request.CartDeleteListDTO;
 import com.travel.cart.service.CartService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/travel/src/main/java/com/travel/cart/controller/CartController.java
+++ b/travel/src/main/java/com/travel/cart/controller/CartController.java
@@ -2,6 +2,7 @@ package com.travel.cart.controller;
 
 import com.travel.cart.dto.request.CartAddDTO;
 import com.travel.cart.dto.request.CartDeleteListDTO;
+import com.travel.cart.dto.request.CartUpdateDTO;
 import com.travel.cart.service.CartService;
 import com.travel.global.exception.GlobalException;
 import com.travel.global.exception.GlobalExceptionType;
@@ -40,6 +41,13 @@ public class CartController {
         PageResponseDTO carts = cartService.getCarts(pageRequest, userEmail);
 
         return ResponseEntity.ok(carts);
+    }
+
+    @PatchMapping("/{cartId}")
+    public ResponseEntity<Void> updateCart(@PathVariable Long cartId, @Valid @RequestBody CartUpdateDTO cartUpdateDTO, String userEmail) {
+        cartService.updateCart(cartId, cartUpdateDTO, userEmail);
+
+        return ResponseEntity.ok(null);
     }
 
     @DeleteMapping

--- a/travel/src/main/java/com/travel/cart/controller/CartController.java
+++ b/travel/src/main/java/com/travel/cart/controller/CartController.java
@@ -6,9 +6,7 @@ import com.travel.cart.service.CartService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -21,8 +19,15 @@ public class CartController {
 
     @PostMapping
     public ResponseEntity<Void> addCart(@Valid @RequestBody CartAddDTO cartAddDTO, String userEmail) {
-
         cartService.addCart(cartAddDTO, userEmail);
+
+        return ResponseEntity.ok(null);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteCarts(@Valid @RequestBody CartDeleteListDTO cartDeleteListDTO, String userEmail) {
+        cartService.deleteCarts(cartDeleteListDTO, userEmail);
+
         return ResponseEntity.ok(null);
     }
 }

--- a/travel/src/main/java/com/travel/cart/controller/CartController.java
+++ b/travel/src/main/java/com/travel/cart/controller/CartController.java
@@ -3,7 +3,11 @@ package com.travel.cart.controller;
 import com.travel.cart.dto.request.CartAddDTO;
 import com.travel.cart.dto.request.CartDeleteListDTO;
 import com.travel.cart.service.CartService;
+import com.travel.global.exception.GlobalException;
+import com.travel.global.exception.GlobalExceptionType;
+import com.travel.global.response.PageResponseDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +19,7 @@ import javax.validation.Valid;
 @RequestMapping("/carts")
 public class CartController {
 
+    public static final int PAGE_SIZE = 3;
     private final CartService cartService;
 
     @PostMapping
@@ -24,8 +29,22 @@ public class CartController {
         return ResponseEntity.ok(null);
     }
 
+    @GetMapping
+    public ResponseEntity<PageResponseDTO> getCarts(@RequestParam(required = false, defaultValue = "1") int page, String userEmail) {
+        if (page < 1) {
+            throw new GlobalException(GlobalExceptionType.PAGE_INDEX_NOT_POSITIVE_NUMBER);
+        }
+
+        PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
+
+        PageResponseDTO carts = cartService.getCarts(pageRequest, userEmail);
+
+        return ResponseEntity.ok(carts);
+    }
+
     @DeleteMapping
-    public ResponseEntity<Void> deleteCarts(@Valid @RequestBody CartDeleteListDTO cartDeleteListDTO, String userEmail) {
+    public ResponseEntity<Void> deleteCarts(@Valid @RequestBody CartDeleteListDTO cartDeleteListDTO, String
+            userEmail) {
         cartService.deleteCarts(cartDeleteListDTO, userEmail);
 
         return ResponseEntity.ok(null);

--- a/travel/src/main/java/com/travel/cart/dto/request/CartAddDTO.java
+++ b/travel/src/main/java/com/travel/cart/dto/request/CartAddDTO.java
@@ -1,4 +1,4 @@
-package com.travel.cart.dto;
+package com.travel.cart.dto.request;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/travel/src/main/java/com/travel/cart/dto/request/CartDeleteDTO.java
+++ b/travel/src/main/java/com/travel/cart/dto/request/CartDeleteDTO.java
@@ -1,0 +1,14 @@
+package com.travel.cart.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class CartDeleteDTO {
+
+    @NotNull
+    private Long cartId;
+}

--- a/travel/src/main/java/com/travel/cart/dto/request/CartDeleteListDTO.java
+++ b/travel/src/main/java/com/travel/cart/dto/request/CartDeleteListDTO.java
@@ -1,0 +1,16 @@
+package com.travel.cart.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@Setter
+public class CartDeleteListDTO {
+
+    @NotNull
+    @Valid List<CartDeleteDTO> cartIds;
+}

--- a/travel/src/main/java/com/travel/cart/dto/request/CartUpdateDTO.java
+++ b/travel/src/main/java/com/travel/cart/dto/request/CartUpdateDTO.java
@@ -1,0 +1,20 @@
+package com.travel.cart.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class CartUpdateDTO {
+
+    @NotNull
+    private Long productId;
+
+    @NotNull
+    private Long periodOptionId;
+
+    @NotNull
+    private Integer quantity;
+}

--- a/travel/src/main/java/com/travel/cart/dto/response/CartResponseDTO.java
+++ b/travel/src/main/java/com/travel/cart/dto/response/CartResponseDTO.java
@@ -1,0 +1,29 @@
+package com.travel.cart.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class CartResponseDTO {
+
+    private Long cartId;
+
+    private Long productId;
+
+    private Long periodOptionId;
+
+    private Integer cartPrice;
+
+    private String productName;
+
+    private String periodOptionName;
+
+    private String productThumbnail;
+
+    private String productContent;
+
+    private Integer cartQuantity;
+}

--- a/travel/src/main/java/com/travel/cart/entity/Cart.java
+++ b/travel/src/main/java/com/travel/cart/entity/Cart.java
@@ -20,7 +20,7 @@ public class Cart extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "cart_id")
-    private Long id;
+    private Long cartId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/travel/src/main/java/com/travel/cart/entity/Cart.java
+++ b/travel/src/main/java/com/travel/cart/entity/Cart.java
@@ -5,10 +5,7 @@ import com.travel.global.entity.BaseEntity;
 import com.travel.member.entity.Member;
 import com.travel.product.entity.PeriodOption;
 import com.travel.product.entity.Product;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
@@ -23,18 +20,22 @@ public class Cart extends BaseEntity {
     @Column(name = "cart_id")
     private Long cartId;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "period_option_id")
     private PeriodOption periodOption;
 
+    @Setter
     @Column(name = "cart_quantity")
     private Integer cartQuantity;
 

--- a/travel/src/main/java/com/travel/cart/entity/Cart.java
+++ b/travel/src/main/java/com/travel/cart/entity/Cart.java
@@ -1,5 +1,6 @@
 package com.travel.cart.entity;
 
+import com.travel.cart.dto.response.CartResponseDTO;
 import com.travel.global.entity.BaseEntity;
 import com.travel.member.entity.Member;
 import com.travel.product.entity.PeriodOption;
@@ -43,5 +44,19 @@ public class Cart extends BaseEntity {
         this.product = product;
         this.periodOption = periodOption;
         this.cartQuantity = cartQuantity;
+    }
+
+    public CartResponseDTO toCartResponseDTO() {
+        return CartResponseDTO.builder()
+                .cartId(this.getCartId())
+                .productId(this.getProduct().getProductId())
+                .periodOptionId(this.getPeriodOption().getPeriodOptionId())
+                .cartPrice(this.getProduct().getProductPrice() * this.getCartQuantity())
+                .productName(this.getProduct().getProductName())
+                .periodOptionName(this.getPeriodOption().getOptionName())
+                .productThumbnail(this.getProduct().getProductThumbnail())
+                .productContent(this.getProduct().getProductContent())
+                .cartQuantity(this.getCartQuantity())
+                .build();
     }
 }

--- a/travel/src/main/java/com/travel/cart/exception/CartException.java
+++ b/travel/src/main/java/com/travel/cart/exception/CartException.java
@@ -1,0 +1,15 @@
+package com.travel.cart.exception;
+
+import com.travel.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CartException extends CustomException {
+
+    private final CartExceptionType cartExceptionType;
+
+    @Override
+    public CartExceptionType getCustomExceptionType() {
+        return cartExceptionType;
+    }
+}

--- a/travel/src/main/java/com/travel/cart/exception/CartExceptionType.java
+++ b/travel/src/main/java/com/travel/cart/exception/CartExceptionType.java
@@ -1,0 +1,23 @@
+package com.travel.cart.exception;
+
+import com.travel.global.exception.CustomExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum CartExceptionType implements CustomExceptionType {
+
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 장바구니 상품입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMsg;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+    @Override
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+}

--- a/travel/src/main/java/com/travel/cart/repository/CartRepository.java
+++ b/travel/src/main/java/com/travel/cart/repository/CartRepository.java
@@ -5,10 +5,13 @@ import com.travel.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByMemberAndCartId(Member member, Long cartId);
+
+    List<Cart> findByMember(Member member);
 }

--- a/travel/src/main/java/com/travel/cart/repository/CartRepository.java
+++ b/travel/src/main/java/com/travel/cart/repository/CartRepository.java
@@ -1,9 +1,14 @@
 package com.travel.cart.repository;
 
 import com.travel.cart.entity.Cart;
+import com.travel.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
+
+    Optional<Cart> findByMemberAndId(Member member, Long cartId);
 }

--- a/travel/src/main/java/com/travel/cart/repository/CartRepository.java
+++ b/travel/src/main/java/com/travel/cart/repository/CartRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
-    Optional<Cart> findByMemberAndId(Member member, Long cartId);
+    Optional<Cart> findByMemberAndCartId(Member member, Long cartId);
 }

--- a/travel/src/main/java/com/travel/cart/service/CartService.java
+++ b/travel/src/main/java/com/travel/cart/service/CartService.java
@@ -2,6 +2,7 @@ package com.travel.cart.service;
 
 import com.travel.cart.dto.request.CartAddDTO;
 import com.travel.cart.dto.request.CartDeleteListDTO;
+import com.travel.cart.dto.request.CartUpdateDTO;
 import com.travel.global.response.PageResponseDTO;
 import org.springframework.data.domain.Pageable;
 
@@ -10,6 +11,8 @@ public interface CartService {
     void addCart(CartAddDTO cartAddDTO, String userEmail);
 
     PageResponseDTO getCarts(Pageable pageable, String userEmail);
+
+    void updateCart(Long cartId, CartUpdateDTO cartUpdateDTO, String userEmail);
 
     void deleteCarts(CartDeleteListDTO cartDeleteListDTO, String userEmail);
 }

--- a/travel/src/main/java/com/travel/cart/service/CartService.java
+++ b/travel/src/main/java/com/travel/cart/service/CartService.java
@@ -1,8 +1,11 @@
 package com.travel.cart.service;
 
-import com.travel.cart.dto.CartAddDTO;
+import com.travel.cart.dto.request.CartAddDTO;
+import com.travel.cart.dto.request.CartDeleteListDTO;
 
 public interface CartService {
 
     void addCart(CartAddDTO cartAddDTO, String userEmail);
+
+    void deleteCarts(CartDeleteListDTO cartDeleteListDTO, String userEmail);
 }

--- a/travel/src/main/java/com/travel/cart/service/CartService.java
+++ b/travel/src/main/java/com/travel/cart/service/CartService.java
@@ -2,10 +2,14 @@ package com.travel.cart.service;
 
 import com.travel.cart.dto.request.CartAddDTO;
 import com.travel.cart.dto.request.CartDeleteListDTO;
+import com.travel.global.response.PageResponseDTO;
+import org.springframework.data.domain.Pageable;
 
 public interface CartService {
 
     void addCart(CartAddDTO cartAddDTO, String userEmail);
+
+    PageResponseDTO getCarts(Pageable pageable, String userEmail);
 
     void deleteCarts(CartDeleteListDTO cartDeleteListDTO, String userEmail);
 }

--- a/travel/src/main/java/com/travel/cart/service/impl/CartServiceImpl.java
+++ b/travel/src/main/java/com/travel/cart/service/impl/CartServiceImpl.java
@@ -2,6 +2,7 @@ package com.travel.cart.service.impl;
 
 import com.travel.cart.dto.request.CartAddDTO;
 import com.travel.cart.dto.request.CartDeleteListDTO;
+import com.travel.cart.dto.request.CartUpdateDTO;
 import com.travel.cart.dto.response.CartResponseDTO;
 import com.travel.cart.entity.Cart;
 import com.travel.cart.exception.CartException;
@@ -59,7 +60,7 @@ public class CartServiceImpl implements CartService {
     @Override
     public PageResponseDTO getCarts(Pageable pageable, String userEmail) {
         Member member = memberRepository.findByMemberEmail(userEmail)
-                        .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
 
         List<Cart> cartList = cartRepository.findByMember(member);
 
@@ -71,9 +72,30 @@ public class CartServiceImpl implements CartService {
     }
 
     @Override
+    public void updateCart(Long cartId, CartUpdateDTO cartUpdateDTO, String userEmail) {
+        Member member = memberRepository.findByMemberEmail(userEmail)
+                .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
+
+        Cart cart = cartRepository.findByMemberAndCartId(member, cartId)
+                .orElseThrow(() -> new CartException(CartExceptionType.CART_NOT_FOUND));
+
+        Product product = productRepository.findById(cartUpdateDTO.getProductId())
+                .orElseThrow(() -> new ProductException(ProductExceptionType.PRODUCT_NOT_FOUND));
+
+        PeriodOption periodOption = periodOptionRepository.findByProductAndPeriodOptionId(product, cartUpdateDTO.getPeriodOptionId())
+                .orElseThrow(() -> new ProductException(ProductExceptionType.PERIOD_OPTION_NOT_FOUND));
+
+        cart.setProduct(product);
+        cart.setPeriodOption(periodOption);
+        cart.setCartQuantity(cartUpdateDTO.getQuantity());
+
+        cartRepository.save(cart);
+    }
+
+    @Override
     public void deleteCarts(CartDeleteListDTO cartDeleteListDTO, String userEmail) {
         Member member = memberRepository.findByMemberEmail(userEmail)
-                        .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
 
         List<Cart> cartList = cartDeleteListDTO.getCartIds().stream()
                 .map(cartDeleteDTO -> cartRepository.findByMemberAndCartId(member, cartDeleteDTO.getCartId())

--- a/travel/src/main/java/com/travel/cart/service/impl/CartServiceImpl.java
+++ b/travel/src/main/java/com/travel/cart/service/impl/CartServiceImpl.java
@@ -58,7 +58,7 @@ public class CartServiceImpl implements CartService {
                         .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
 
         List<Cart> cartList = cartDeleteListDTO.getCartIds().stream()
-                .map(cartDeleteDTO -> cartRepository.findByMemberAndId(member, cartDeleteDTO.getCartId())
+                .map(cartDeleteDTO -> cartRepository.findByMemberAndCartId(member, cartDeleteDTO.getCartId())
                         .orElseThrow(() -> new CartException(CartExceptionType.CART_NOT_FOUND)))
                 .collect(Collectors.toList());
 

--- a/travel/src/main/java/com/travel/cart/service/impl/CartServiceImpl.java
+++ b/travel/src/main/java/com/travel/cart/service/impl/CartServiceImpl.java
@@ -1,7 +1,10 @@
 package com.travel.cart.service.impl;
 
-import com.travel.cart.dto.CartAddDTO;
+import com.travel.cart.dto.request.CartAddDTO;
+import com.travel.cart.dto.request.CartDeleteListDTO;
 import com.travel.cart.entity.Cart;
+import com.travel.cart.exception.CartException;
+import com.travel.cart.exception.CartExceptionType;
 import com.travel.cart.repository.CartRepository;
 import com.travel.cart.service.CartService;
 import com.travel.member.entity.Member;
@@ -16,6 +19,9 @@ import com.travel.product.repository.PeriodOptionRepository;
 import com.travel.product.repository.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +50,18 @@ public class CartServiceImpl implements CartService {
                 .periodOption(periodOption)
                 .cartQuantity(cartAddDTO.getQuantity())
                 .build());
+    }
+
+    @Override
+    public void deleteCarts(CartDeleteListDTO cartDeleteListDTO, String userEmail) {
+        Member member = memberRepository.findByMemberEmail(userEmail)
+                        .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
+
+        List<Cart> cartList = cartDeleteListDTO.getCartIds().stream()
+                .map(cartDeleteDTO -> cartRepository.findByMemberAndId(member, cartDeleteDTO.getCartId())
+                        .orElseThrow(() -> new CartException(CartExceptionType.CART_NOT_FOUND)))
+                .collect(Collectors.toList());
+
+        cartRepository.deleteAll(cartList);
     }
 }

--- a/travel/src/main/java/com/travel/cart/service/impl/CartServiceImpl.java
+++ b/travel/src/main/java/com/travel/cart/service/impl/CartServiceImpl.java
@@ -2,11 +2,13 @@ package com.travel.cart.service.impl;
 
 import com.travel.cart.dto.request.CartAddDTO;
 import com.travel.cart.dto.request.CartDeleteListDTO;
+import com.travel.cart.dto.response.CartResponseDTO;
 import com.travel.cart.entity.Cart;
 import com.travel.cart.exception.CartException;
 import com.travel.cart.exception.CartExceptionType;
 import com.travel.cart.repository.CartRepository;
 import com.travel.cart.service.CartService;
+import com.travel.global.response.PageResponseDTO;
 import com.travel.member.entity.Member;
 import com.travel.member.exception.MemberException;
 import com.travel.member.exception.MemberExceptionType;
@@ -18,6 +20,8 @@ import com.travel.product.exception.ProductExceptionType;
 import com.travel.product.repository.PeriodOptionRepository;
 import com.travel.product.repository.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -50,6 +54,20 @@ public class CartServiceImpl implements CartService {
                 .periodOption(periodOption)
                 .cartQuantity(cartAddDTO.getQuantity())
                 .build());
+    }
+
+    @Override
+    public PageResponseDTO getCarts(Pageable pageable, String userEmail) {
+        Member member = memberRepository.findByMemberEmail(userEmail)
+                        .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
+
+        List<Cart> cartList = cartRepository.findByMember(member);
+
+        List<CartResponseDTO> cartResponseDTOList = cartList.stream()
+                .map(Cart::toCartResponseDTO)
+                .collect(Collectors.toList());
+
+        return new PageResponseDTO(new PageImpl<>(cartResponseDTOList, pageable, cartResponseDTOList.size()));
     }
 
     @Override

--- a/travel/src/main/java/com/travel/order/controller/OrderController.java
+++ b/travel/src/main/java/com/travel/order/controller/OrderController.java
@@ -29,14 +29,14 @@ public class OrderController {
     }
 
     @GetMapping
-    public ResponseEntity<PageResponseDTO> getOrders(@RequestParam(required = false, defaultValue = "1") int page, String userEmail) {
+    public ResponseEntity<PageResponseDTO> getOrders(@RequestParam(required = false, defaultValue = "1") int page, String status, String userEmail) {
         if (page < 1) {
             throw new GlobalException(GlobalExceptionType.PAGE_INDEX_NOT_POSITIVE_NUMBER);
         }
 
         PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
 
-        PageResponseDTO orders = orderService.getOrders(pageRequest, userEmail);
+        PageResponseDTO orders = orderService.getOrders(pageRequest, status,userEmail);
 
         return ResponseEntity.ok(orders);
     }


### PR DESCRIPTION
## Motivation

#23
장바구니 상품 삭제, 조회, 수정 기능 구현

## Key Changes

작업한 내용의 주요 변경사항을 자세히 나열하세요

- Change 1
  - https://github.com/KDT3-Final-6/final-project-BE/issues/23
     - 64925a6ddcb616a1f2b0abd303589cb855462854: 장바구니 삭제 리퀘스트 DTO 생성
     - 67f85984fdfc0f7a68a2383644f2e0c29fccb365: CartRepository에 쿼리 메서드 추가
     - d06ea5c28e8089c86e40cb37d5addb48e426729c: Cart 커스텀 예외 생성
     - f491f4d50047d9bb289995b75560e0c4c39c9a29: CartService에 장바구니 상품 삭제(deleteCarts) 기능 구현
     - 864a6e1495d8202a3db28aea018076236673a5ea: CartController에 장바구니 상품 삭제(deleteCarts) API 구현
     - 501b3cf1c31caf1d7d9143f15d66c0bd3e8784b9: 장바구니 목록 조회 응답 DTO 생성
     - 29789c189d97eea903ec2e18dc64232bbde7f0ba: CartRepository에 쿼리 메서드 추가
     - 81847b50f880292f0434b7c9286c51b036363385: Cart 엔티티를 CartResponseDTO로 바꾸는 메서드 추가
     - 3fbf2381c32cd1a88a09eee9f69c203c7e995d5a: CartService에 장바구니 목록 조회(getCarts) 기능 구현
     - 626d53dd854a5de6ed1bafbe8652b6f5c164b2c1: CartController에 장바구니 목록 조회(getCarts) API 구현
     - c8f46a2f339a1bef6c4bd75e4df5a24684b50277: 장바구니 수정 리퀘스트 DTO 생성
     - 38c9a32a37b5ae9bf7217082d7e1d74eb0697ed1: Cart 엔티티에 @Setter 추가
     - 15140bd1be6ebf5537f9c9fcb9b68c9cc0f08204: CartService에 장바구니 상품 수정(updateCart) 기능 구현
     - fd93198c4ff0ba03f2f648a5efa824ac32d84279: CartController에 장바구니 상품 수정(updateCart) API 구현
- Change 2
   - 기타
      - 574e0e6c0fefdb91b1741d8c53a8a4b86765a6c6: CartAddDTO 위치 변경
      - cbe5b8307686be826eb57b8973ad7eb321c7f815: Cart 엔티티의 id -> cartId로 변경
      - 


## To reviewers

실수로 브랜치를 cart말고 order에서 푸쉬했습니다.

