### PR TITLE
Feature/product 상품 수정, PeriodOption에 Status 추가

### DIFF
--- a/travel/src/main/java/com/travel/admin/controller/AdminController.java
+++ b/travel/src/main/java/com/travel/admin/controller/AdminController.java
@@ -3,8 +3,8 @@ package com.travel.admin.controller;
 import com.travel.global.exception.GlobalException;
 import com.travel.global.exception.GlobalExceptionType;
 import com.travel.global.response.PageResponseDTO;
-import com.travel.order.service.OrderService;
 import com.travel.product.dto.request.PeriodPostRequestDTO;
+import com.travel.product.dto.request.ProductPatchRequestDTO;
 import com.travel.product.dto.request.ProductPostRequestDTO;
 import com.travel.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,6 @@ public class AdminController {
     public static final int PAGE_SIZE = 3;
 
     private final ProductService productService;
-    private final OrderService orderService;
 
     @PostMapping("/products")
     public ResponseEntity<String> postProduct(@RequestBody @Valid ProductPostRequestDTO productPostRequestDTO) {
@@ -49,7 +48,6 @@ public class AdminController {
     }
 
     /**
-     *
      * @param productId
      * delete지만 실제 db에서는 삭제 하지 않는다
      * 그냥 Member가 못보게 Status만 숨김으로 변경
@@ -58,6 +56,13 @@ public class AdminController {
     @DeleteMapping("/products/{productId}")
     public ResponseEntity<String> deleteProduct(@PathVariable Long productId) {
         productService.deleteProduct(productId);
+        return ResponseEntity.ok(null);
+    }
+
+    @PatchMapping("/products/{productId}")
+    public ResponseEntity<String> patchProduct(@PathVariable Long productId,
+                                               @RequestBody ProductPatchRequestDTO productPatchRequestDTO) {
+        productService.updateProduct(productId, productPatchRequestDTO);
         return ResponseEntity.ok(null);
     }
 

--- a/travel/src/main/java/com/travel/product/dto/request/PeriodOptionDTO.java
+++ b/travel/src/main/java/com/travel/product/dto/request/PeriodOptionDTO.java
@@ -29,6 +29,9 @@ public class PeriodOptionDTO {
     @Positive
     private Integer minimumQuantity;
 
+    @NotBlank
+    private String periodOptionStatus;
+
     public void setDates() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
 

--- a/travel/src/main/java/com/travel/product/dto/request/PeriodPostRequestDTO.java
+++ b/travel/src/main/java/com/travel/product/dto/request/PeriodPostRequestDTO.java
@@ -1,6 +1,7 @@
 package com.travel.product.dto.request;
 
 import com.travel.product.entity.PeriodOption;
+import com.travel.product.entity.Status;
 import lombok.Getter;
 
 import javax.validation.Valid;
@@ -40,9 +41,19 @@ public class PeriodPostRequestDTO {
                         .endDate(periodOption.getEndDate())
                         .maximumQuantity(periodOption.getMaximumQuantity())
                         .minimumQuantity(periodOption.getMinimumQuantity())
+                        .periodOptionStatus(setEnumProductStatus(periodOption.getPeriodOptionStatus()))
                         .build())
                 .collect(toList());
 
         return periodOptionList;
+    }
+
+    public Status setEnumProductStatus(String productStatus) {
+        if (productStatus.equals(Status.FORSALE.getKorean())) {
+            return Status.FORSALE;
+        } else if (productStatus.equals(Status.SOLDOUT.getKorean())) {
+            return Status.SOLDOUT;
+        }
+        return Status.HIDDEN;
     }
 }

--- a/travel/src/main/java/com/travel/product/dto/request/ProductPatchRequestDTO.java
+++ b/travel/src/main/java/com/travel/product/dto/request/ProductPatchRequestDTO.java
@@ -1,0 +1,48 @@
+package com.travel.product.dto.request;
+
+import com.travel.product.entity.Product;
+import com.travel.product.entity.Status;
+import lombok.Getter;
+
+import javax.validation.constraints.Positive;
+import java.util.Optional;
+
+@Getter
+public class ProductPatchRequestDTO {
+
+    private String productName;
+    private String productThumbnail;
+    private String productStatus;
+    private String productContent;
+    private String contentDetail;
+
+    @Positive
+    private Integer productPrice;
+
+    public Status setEnumProductStatus(String productStatus) {
+        if (productStatus.equals(Status.FORSALE.getKorean())) {
+            return Status.FORSALE;
+        } else if (productStatus.equals(Status.SOLDOUT.getKorean())) {
+            return Status.SOLDOUT;
+        }
+        return Status.HIDDEN;
+    }
+
+    public Product toEntity(Product product) {
+        productName = Optional.ofNullable(productName).orElse(product.getProductName());
+        productThumbnail = Optional.ofNullable(productThumbnail).orElse(product.getProductThumbnail());
+        productStatus = Optional.ofNullable(productStatus).orElse(product.getProductStatus().getKorean());
+        productContent = Optional.ofNullable(productContent).orElse(product.getProductContent());
+        contentDetail = Optional.ofNullable(contentDetail).orElse(product.getContentDetail());
+        productPrice=Optional.ofNullable(productPrice).orElse(product.getProductPrice());
+
+        return Product.builder()
+                .productName(productName)
+                .productThumbnail(productThumbnail)
+                .productPrice(productPrice)
+                .productStatus(setEnumProductStatus(productStatus))
+                .productContent(productContent)
+                .contentDetail(contentDetail)
+                .build();
+    }
+}

--- a/travel/src/main/java/com/travel/product/entity/PeriodOption.java
+++ b/travel/src/main/java/com/travel/product/entity/PeriodOption.java
@@ -50,12 +50,16 @@ public class PeriodOption {
     @Column(name = "sold_quantity")
     private Integer soldQuantity;
 
+    @Column(name = "period_option_status")
+    @Enumerated(EnumType.STRING)
+    private Status periodOptionStatus;
+
     public void setProduct(Product product) {
         this.product = product;
     }
 
     @Builder
-    public PeriodOption(Product product, String optionName, LocalDate startDate, LocalDate endDate, Integer maximumQuantity, Integer minimumQuantity) {
+    public PeriodOption(Product product, String optionName, LocalDate startDate, LocalDate endDate, Integer maximumQuantity, Integer minimumQuantity, Status periodOptionStatus) {
         this.product = product;
         this.optionName = optionName;
         this.startDate = startDate;
@@ -63,6 +67,7 @@ public class PeriodOption {
         this.period = Period.between(startDate, endDate).getDays() + 1;
         this.maximumQuantity = maximumQuantity;
         this.minimumQuantity = minimumQuantity;
+        this.periodOptionStatus = periodOptionStatus;
         this.soldQuantity = 0;
     }
 

--- a/travel/src/main/java/com/travel/product/entity/Product.java
+++ b/travel/src/main/java/com/travel/product/entity/Product.java
@@ -58,6 +58,15 @@ public class Product extends BaseEntity {
         product.productStatus = Status.HIDDEN;
     }
 
+    public void updateProduct(Product product) {
+        this.productName = product.getProductName();
+        this.productThumbnail = product.getProductThumbnail();
+        this.productPrice = product.getProductPrice();
+        this.productStatus = product.getProductStatus();
+        this.productContent = product.getProductContent();
+        this.contentDetail = product.getContentDetail();
+    }
+
     @Builder
     public Product(String productName, String productThumbnail, Integer productPrice, Status productStatus, String productContent, String contentDetail) {
         this.productName = productName;

--- a/travel/src/main/java/com/travel/product/service/ProductService.java
+++ b/travel/src/main/java/com/travel/product/service/ProductService.java
@@ -2,6 +2,7 @@ package com.travel.product.service;
 
 import com.travel.global.response.PageResponseDTO;
 import com.travel.product.dto.request.PeriodPostRequestDTO;
+import com.travel.product.dto.request.ProductPatchRequestDTO;
 import com.travel.product.dto.request.ProductPostRequestDTO;
 import com.travel.product.dto.response.ProductDetailGetResponseDTO;
 import com.travel.product.dto.response.ProductListGetResponseDTO;
@@ -102,5 +103,13 @@ public class ProductService {
                 .orElseThrow(() -> new ProductException(ProductExceptionType.PRODUCT_NOT_FOUND));
 
         product.changeStatusToHidden(product);
+    }
+
+    @Transactional
+    public void updateProduct(Long id, ProductPatchRequestDTO productPatchRequestDTO) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new ProductException(ProductExceptionType.PRODUCT_NOT_FOUND));
+
+        product.updateProduct(productPatchRequestDTO.toEntity(product));
     }
 }


### PR DESCRIPTION
## Motivation

#28 
해당 이슈의 두번째 체크박스까지 완료

## Key Changes

- Change 1
  - 525833094a9250903f970899a3621099a29ce432 ~ 755909359a63cbd71b4b2d78f7ccf66d30e5edc1 : 상품 (기간 옵션, 카테고리) 제외 수정 기능 구현
- Change 2
  - b1f93f53c731757b3e2c4df0402af6886420a886, 6d4c4d0829b164e9c4d5135a419546a615833f7f : PeriodOption에 Status periodOptionStatus 추가 후 기존에 PeriodOption 사용 로직들에 변경사항 반영

## To reviewers
- feature/product에서 진행해야 될걸 실수로 feature/develop 브랜치를 만들어서 진행했습니다.
제목은 Feature/product이지만 실제 merge 브랜치는 feature/develop 입니다.
- Patch를 구현할때 프론트에서 바꾸지 않는 값은 기본값으로 보내줄 것을 가정하고 null 처리를 안했다가 그래도 백 프론트 모두 확인하는게 맞다는 조언을 듣고 Optional.orelse로 null 체크를 하였습니다.
- Patch를 구현할때 Product Entity안에 updateProduct(Dto dto) 이런식으로 구현하여 해결하려 했지만 핵심 로직인 도메인에서 DTO를 의존하는건 좋지 않은 설계라 들어 updateProduct((Dto -> toEntity)Product product) 의 방식으로 구현하였습니다

