### PR TITLE
Refactor/search 검색 기능, memberId null로 나오는 문제, Enum 값 한글로 출력 수정

### DIFF
--- a/travel/src/main/java/com/travel/order/dto/response/OrderAdminResponseDTO.java
+++ b/travel/src/main/java/com/travel/order/dto/response/OrderAdminResponseDTO.java
@@ -33,7 +33,7 @@ public class OrderAdminResponseDTO {
 
     private Integer productProductQuantity;
 
-    private OrderStatus orderStatus;
+    private String orderStatus;
 
     @Builder
     public OrderAdminResponseDTO(Long orderId, Long productId, Long memberId, String memberName, String memberEmail, String productName, String productThumbnail, Integer productPrice, LocalDateTime orderDate, String optionName, Integer productProductQuantity, OrderStatus orderStatus) {
@@ -48,6 +48,6 @@ public class OrderAdminResponseDTO {
         this.orderDate = orderDate;
         this.optionName = optionName;
         this.productProductQuantity = productProductQuantity;
-        this.orderStatus = orderStatus;
+        this.orderStatus = orderStatus.getKorean();
     }
 }

--- a/travel/src/main/java/com/travel/order/dto/response/OrderListAdminResponseDTO.java
+++ b/travel/src/main/java/com/travel/order/dto/response/OrderListAdminResponseDTO.java
@@ -17,12 +17,12 @@ public class OrderListAdminResponseDTO {
 
     private List<OrderAdminResponseDTO> orderList;
 
-    private PaymentMethod paymentMethod;
+    private String paymentMethod;
 
     @Builder
     public OrderListAdminResponseDTO(List<OrderAdminResponseDTO> orderList, Order order) {
         this.orderDate = LocalDate.from(orderList.get(0).getOrderDate());
         this.orderList = orderList;
-        this.paymentMethod = order.getPaymentMethod();
+        this.paymentMethod = order.getPaymentMethod().getKorean();
     }
 }

--- a/travel/src/main/java/com/travel/order/dto/response/OrderListResponseDTO.java
+++ b/travel/src/main/java/com/travel/order/dto/response/OrderListResponseDTO.java
@@ -1,7 +1,6 @@
 package com.travel.order.dto.response;
 
 import com.travel.order.entity.Order;
-import com.travel.order.entity.PaymentMethod;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,12 +16,12 @@ public class OrderListResponseDTO {
 
     private List<OrderResponseDTO> orderList;
 
-    private PaymentMethod paymentMethod;
+    private String paymentMethod;
 
     @Builder
     public OrderListResponseDTO(List<OrderResponseDTO> orderList, Order order) {
         this.orderDate = LocalDate.from(orderList.get(0).getOrderDate());
         this.orderList = orderList;
-        this.paymentMethod = order.getPaymentMethod();
+        this.paymentMethod = order.getPaymentMethod().getKorean();
     }
 }

--- a/travel/src/main/java/com/travel/order/dto/response/OrderResponseDTO.java
+++ b/travel/src/main/java/com/travel/order/dto/response/OrderResponseDTO.java
@@ -27,7 +27,7 @@ public class OrderResponseDTO {
 
     private Integer productProductQuantity;
 
-    private OrderStatus orderStatus;
+    private String orderStatus;
 
     @Builder
     public OrderResponseDTO(Long orderId, Long productId, String productName, String productThumbnail, Integer productPrice, LocalDateTime orderDate, String optionName, Integer productProductQuantity, OrderStatus orderStatus) {
@@ -39,6 +39,6 @@ public class OrderResponseDTO {
         this.orderDate = orderDate;
         this.optionName = optionName;
         this.productProductQuantity = productProductQuantity;
-        this.orderStatus = orderStatus;
+        this.orderStatus = orderStatus.getKorean();
     }
 }

--- a/travel/src/main/java/com/travel/order/entity/OrderStatus.java
+++ b/travel/src/main/java/com/travel/order/entity/OrderStatus.java
@@ -2,9 +2,9 @@ package com.travel.order.entity;
 
 public enum OrderStatus {
 
-    WAITING_FOR_PAYMENT("결제 대기"),
-    COMPLETE_PAYMENT("결제 완료"),
-    WITHDRAW_ORDER("주문 취소");
+    WAITING_FOR_PAYMENT("결제대기"),
+    COMPLETE_PAYMENT("결제완료"),
+    WITHDRAW_ORDER("주문취소");
 
     private String korean;
 

--- a/travel/src/main/java/com/travel/product/entity/Product.java
+++ b/travel/src/main/java/com/travel/product/entity/Product.java
@@ -3,6 +3,7 @@ package com.travel.product.entity;
 import com.travel.global.entity.BaseEntity;
 import com.travel.image.Image;
 import com.travel.post.entity.Post;
+import com.travel.search.dto.response.SearchResultResponseDTO;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -95,6 +96,16 @@ public class Product extends BaseEntity {
                 .product(this)
                 .periodOption(periodOption)
                 .quantity(quantity)
+                .build();
+    }
+
+    public SearchResultResponseDTO toSearchResultResponseDTO(Boolean isWished) {
+        return SearchResultResponseDTO.builder()
+                .productId(this.productId)
+                .productName(this.productName)
+                .productThumbnail(this.productThumbnail)
+                .productPrice(this.productPrice)
+                .isWished(isWished)
                 .build();
     }
 }

--- a/travel/src/main/java/com/travel/product/entity/PurchasedProduct.java
+++ b/travel/src/main/java/com/travel/product/entity/PurchasedProduct.java
@@ -85,6 +85,7 @@ public class PurchasedProduct {
         return OrderAdminResponseDTO.builder()
                 .orderId(this.order.getOrderId())
                 .productId(this.product.getProductId())
+                .memberId(member.getMemberId())
                 .memberName(member.getMemberName())
                 .memberEmail(member.getMemberEmail())
                 .productName(this.purchasedProductName)

--- a/travel/src/main/java/com/travel/search/controller/SearchController.java
+++ b/travel/src/main/java/com/travel/search/controller/SearchController.java
@@ -37,17 +37,16 @@ public class SearchController {
     @GetMapping
     public ResponseEntity<PageResponseDTO> searchProducts(
             @RequestParam(required = false, defaultValue = "1") int page,
-            @RequestParam(required = false) String title,
-            @RequestParam(required = false) String category,
-            @RequestParam(required = false) String startDate,
-            @RequestParam(required = false) String endDate) {
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String sortTarget
+            ) {
 
         if (page < 1) {
             throw new GlobalException(GlobalExceptionType.PAGE_INDEX_NOT_POSITIVE_NUMBER);
         }
         PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
 
-        PageResponseDTO pageResponseDTO = searchService.searchProducts(pageRequest, title, category, startDate, endDate);
+        PageResponseDTO pageResponseDTO = searchService.searchProducts(pageRequest, keyword, sortTarget);
 
         return ResponseEntity.ok(pageResponseDTO);
     }

--- a/travel/src/main/java/com/travel/search/dto/request/SortTarget.java
+++ b/travel/src/main/java/com/travel/search/dto/request/SortTarget.java
@@ -1,0 +1,18 @@
+package com.travel.search.dto.request;
+
+public enum SortTarget {
+
+    BY_PRICE_DESC("가격높은순"),
+    BY_PRICE_ASC("가격낮은순"),
+    BY_POPULARITY("인기순");
+
+    private String korean;
+
+    public String getKorean() {
+        return korean;
+    }
+
+    SortTarget(String korean) {
+        this.korean = korean;
+    }
+}

--- a/travel/src/main/java/com/travel/search/dto/response/SearchResultResponseDTO.java
+++ b/travel/src/main/java/com/travel/search/dto/response/SearchResultResponseDTO.java
@@ -1,0 +1,20 @@
+package com.travel.search.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SearchResultResponseDTO {
+
+    private Long productId;
+
+    private String productName;
+
+    private String productThumbnail;
+
+    private Integer productPrice;
+
+    private Boolean isWished;
+
+}

--- a/travel/src/main/java/com/travel/search/service/SearchService.java
+++ b/travel/src/main/java/com/travel/search/service/SearchService.java
@@ -41,16 +41,13 @@ public class SearchService {
 
     public PageResponseDTO searchProducts(
             Pageable pageable,
-            String title,
-            String categoryName,
-            String startDate,
-            String endDate) {
+            String keyword,
+            String sortTarget
+            ) {
 
-        List<Product> products = productRepository.findByProductStatusNot(Status.HIDDEN);
+        List<Product> categoryProducts = findCategoryNameProducts(keyword);
 
-        List<Product> categoryProducts = categoryNameNotNull(categoryName);
-
-        List<Product> nameContainingProducts = titleNotNull(title);
+        List<Product> nameContainingProducts = findTitleProducts(keyword);
 
         List<Product> periodOptionProducts = dateNotNull(startDate, endDate);
 

--- a/travel/src/main/java/com/travel/search/service/SearchService.java
+++ b/travel/src/main/java/com/travel/search/service/SearchService.java
@@ -1,25 +1,30 @@
 package com.travel.search.service;
 
-import com.travel.global.exception.GlobalException;
-import com.travel.global.exception.GlobalExceptionType;
 import com.travel.global.response.PageResponseDTO;
 import com.travel.product.dto.response.ProductCategoryToProductPage;
-import com.travel.product.entity.*;
+import com.travel.product.entity.Category;
+import com.travel.product.entity.Product;
+import com.travel.product.entity.ProductCategory;
+import com.travel.product.entity.Status;
 import com.travel.product.exception.ProductException;
 import com.travel.product.exception.ProductExceptionType;
 import com.travel.product.repository.CategoryRepository;
-import com.travel.product.repository.PeriodOptionRepository;
 import com.travel.product.repository.ProductCategoryRepository;
 import com.travel.product.repository.product.ProductRepository;
+import com.travel.search.dto.request.SortTarget;
+import com.travel.search.dto.response.SearchResultResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +34,6 @@ public class SearchService {
     private final CategoryRepository categoryRepository;
     private final ProductCategoryRepository productCategoryRepository;
     private final ProductRepository productRepository;
-    private final PeriodOptionRepository periodOptionRepository;
 
     public ProductCategoryToProductPage displayProductsByCategory(Pageable pageable, String categoryName) {
 
@@ -43,67 +47,73 @@ public class SearchService {
             Pageable pageable,
             String keyword,
             String sortTarget
-            ) {
+    ) {
 
         List<Product> categoryProducts = findCategoryNameProducts(keyword);
 
         List<Product> nameContainingProducts = findTitleProducts(keyword);
 
-        List<Product> periodOptionProducts = dateNotNull(startDate, endDate);
-
-        List<Product> productList = products.stream()
-                .filter(product -> categoryProducts == null || categoryProducts.contains(product))
-                .filter(product -> nameContainingProducts == null || nameContainingProducts.contains(product))
-                .filter(product -> periodOptionProducts == null || periodOptionProducts.contains(product))
+        List<Product> productList = Stream.of(categoryProducts, nameContainingProducts)
+                .flatMap(Collection::stream)
+                .distinct()
                 .filter(product -> product.getProductStatus() == Status.FORSALE)
                 .collect(Collectors.toList());
 
-        return new PageResponseDTO(new PageImpl<>(productList, pageable, productList.size()));
-    }
-
-    private List<Product> titleNotNull(String title) {
-        List<Product> nameContainingProducts = null;
-        if (title != null) {
-            nameContainingProducts = productRepository.findByProductNameContaining(title);
+        if (sortTarget != null) {
+            productList = sortList(productList, sortTarget);
         }
 
-        return nameContainingProducts;
-    }
-
-    private List<Product> dateNotNull(String startDate, String endDate) {
-        List<Product> periodOptionProducts = null;
-        if (startDate != null && endDate != null) {
-            LocalDate startLocalDate = validateDate(startDate);
-            LocalDate endLocalDate = validateDate(endDate);
-
-            periodOptionProducts = periodOptionRepository.findByStartDateAndEndDate(startLocalDate, endLocalDate).stream()
-                    .filter(periodOption -> periodOption.getPeriodOptionStatus() == Status.FORSALE)
-                    .map(PeriodOption::getProduct)
-                    .collect(Collectors.toList());
-        }
-
-        return periodOptionProducts;
-    }
-
-    private List<Product> categoryNameNotNull(String categoryName) {
-        List<Product> categoryProducts = null;
-
-        Category category = categoryRepository.findByCategoryName(categoryName)
-                .orElseThrow(() -> new ProductException(ProductExceptionType.CATEGORY_NOT_FOUND));
-
-        categoryProducts = productCategoryRepository.findAllByCategory(category).stream()
-                .map(ProductCategory::getProduct)
+        List<SearchResultResponseDTO> searchResult = productList.stream()
+                .map(product -> product.toSearchResultResponseDTO(true))
                 .collect(Collectors.toList());
 
-        return categoryProducts;
+        return new PageResponseDTO(new PageImpl<>(searchResult, pageable, searchResult.size()));
     }
 
-    private LocalDate validateDate(String date) {
-        String pattern = "^\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$";
-        if (!date.matches(pattern)) {
-            throw new GlobalException(GlobalExceptionType.WRONG_DATE_FORMAT);
+    private List<Product> findTitleProducts(String keyword) {
+        List<Product> productNameContaining = productRepository.findByProductNameContaining(keyword);
+
+        if (productNameContaining == null) {
+            return Collections.emptyList();
         }
 
-        return LocalDate.parse(date);
+        return productNameContaining;
+    }
+
+    private List<Product> findCategoryNameProducts(String keyword) {
+        Category category = categoryRepository.findByCategoryName(keyword)
+                .orElse(null);
+
+        if (category == null) {
+            return Collections.emptyList();
+        }
+
+        return productCategoryRepository.findAllByCategory(category).stream()
+                .map(ProductCategory::getProduct)
+                .collect(Collectors.toList());
+    }
+
+    private List<Product> sortList(List<Product> products, String sortTarget) {
+        SortTarget target = Stream.of(SortTarget.values())
+                .filter(sort -> sortTarget.equals(sort.getKorean()))
+                .findFirst()
+                .orElse(null);
+
+        if (target.equals(SortTarget.BY_PRICE_DESC)) {
+            return products.stream()
+                    .sorted(Comparator.comparing(Product::getProductPrice).reversed())
+                    .collect(Collectors.toList());
+        } else if (target.equals(SortTarget.BY_PRICE_ASC)) {
+            return products.stream()
+                    .sorted(Comparator.comparing(Product::getProductPrice))
+                    .collect(Collectors.toList());
+        }
+//        else if (sort.equals(SortTarget.BY_POPULARITY)) { // 아직 구현 안됨
+//            return products.stream()
+//                    .sorted(Comparator.comparing(Product::get))
+//                    .collect(Collectors.toList());
+//        }
+
+        return products;
     }
 }


### PR DESCRIPTION
## Motivation

#56 
관리자용 주문 내역 리스트 조회시 memberId가 null로 나오는 문제 수정

#57 
Enum 한글로 출력 및 한글로 입력 받도록 수정

#58
검색 기능에 바뀐 카테고리 적용 및 로직 수정

## Key Changes

- Change 1
  - https://github.com/KDT3-Final-6/final-project-BE/issues/56
     - 9c91253d424d0aaafa195f207128dd5cc1aca0ea: toOrderAdminResponseDTO에 빌터 패턴에서 memberId 추가
- Change 2
   - https://github.com/KDT3-Final-6/final-project-BE/issues/57
      - 2b8a6aa441e6c0f5330215094e84dee6a7eea0ea: 주문 내역에 Enum 한글로 출력하도록 수정
- Change 3
   - https://github.com/KDT3-Final-6/final-project-BE/issues/58
      - d15068d9be7faf1bcd983122b53ada6009f8bcac: 검색 기능에 바뀐 카테고리 적용
      - c6862d83b7cd6d67b1ea3574d5a3cccfb27c8f00: 정렬 방식 Enum 생성
      - 90229010b44886cd8c3271a45776681149aea0ad: 검색 ResponseDTO 생성
      - eac88869eae44e335fde1e71aa735e4fbea98249: 검색 기능 로직 수정
- Change 4
   - 기타
      -  738f4de61fa757530658081bf859149a9d4a7315: OrderStatus korean 뛰어쓰기 제거

## To reviewers

검색 정렬 방식에 인기순은 아직 구현되지 않았습니다.

