### PR TITLE
Feature/qna QnA 리스트 조회(회원, 관리자용), QnA 답변 생성(관리자용) 기능 구현 

### DIFF
--- a/travel/src/main/java/com/travel/admin/controller/AdminController.java
+++ b/travel/src/main/java/com/travel/admin/controller/AdminController.java
@@ -5,6 +5,7 @@ import com.travel.global.exception.GlobalExceptionType;
 import com.travel.global.response.PageResponseDTO;
 import com.travel.order.dto.request.OrderApproveDTO;
 import com.travel.order.service.OrderService;
+import com.travel.post.dto.request.QnAAnswerRequestDTO;
 import com.travel.post.service.QnAService;
 import com.travel.product.dto.request.PeriodPostRequestDTO;
 import com.travel.product.dto.request.ProductPatchRequestDTO;
@@ -121,5 +122,12 @@ public class AdminController {
         PageResponseDTO pageResponseDTO = qnAService.getQnAsAdmin(pageRequest, authentication.getName());
 
         return ResponseEntity.ok(pageResponseDTO);
+    }
+
+    @PostMapping("/qna/answers")
+    public ResponseEntity<Void> createAnswer(@RequestBody QnAAnswerRequestDTO qnAAnswerRequestDTO, Authentication authentication) {
+        qnAService.createAnswer(qnAAnswerRequestDTO, authentication.getName());
+
+        return ResponseEntity.ok(null);
     }
 }

--- a/travel/src/main/java/com/travel/admin/controller/AdminController.java
+++ b/travel/src/main/java/com/travel/admin/controller/AdminController.java
@@ -14,6 +14,7 @@ import com.travel.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -88,21 +89,21 @@ public class AdminController {
     }
 
     @GetMapping("/orders")
-    public ResponseEntity<PageResponseDTO> getOrders(@RequestParam(required = false, defaultValue = "1") int page, String userEmail) {
+    public ResponseEntity<PageResponseDTO> getOrders(@RequestParam(required = false, defaultValue = "1") int page, Authentication authentication) {
         if (page < 1) {
             throw new GlobalException(GlobalExceptionType.PAGE_INDEX_NOT_POSITIVE_NUMBER);
         }
 
         PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
 
-        PageResponseDTO orders = orderService.getOrdersAdmin(pageRequest, userEmail);
+        PageResponseDTO orders = orderService.getOrdersAdmin(pageRequest, authentication.getName());
 
         return ResponseEntity.ok(orders);
     }
 
     @PatchMapping("/orders/approvals/{orderId}")
-    public ResponseEntity<Void> approveOrder(@PathVariable Long orderId, @RequestBody OrderApproveDTO orderApproveDTO, String userEmail) {
-        orderService.approveOrder(orderId, orderApproveDTO, userEmail);
+    public ResponseEntity<Void> approveOrder(@PathVariable Long orderId, @RequestBody OrderApproveDTO orderApproveDTO, Authentication authentication) {
+        orderService.approveOrder(orderId, orderApproveDTO, authentication.getName());
 
         return ResponseEntity.ok(null);
     }

--- a/travel/src/main/java/com/travel/admin/controller/AdminController.java
+++ b/travel/src/main/java/com/travel/admin/controller/AdminController.java
@@ -5,6 +5,7 @@ import com.travel.global.exception.GlobalExceptionType;
 import com.travel.global.response.PageResponseDTO;
 import com.travel.order.dto.request.OrderApproveDTO;
 import com.travel.order.service.OrderService;
+import com.travel.post.service.QnAService;
 import com.travel.product.dto.request.PeriodPostRequestDTO;
 import com.travel.product.dto.request.ProductPatchRequestDTO;
 import com.travel.product.dto.request.ProductPostRequestDTO;
@@ -31,6 +32,7 @@ public class AdminController {
 
     private final ProductService productService;
     private final OrderService orderService;
+    private final QnAService qnAService;
 
     @PostMapping("/products")
     public ResponseEntity<String> postProduct(@RequestPart @Valid ProductPostRequestDTO productPostRequestDTO,
@@ -106,5 +108,18 @@ public class AdminController {
         orderService.approveOrder(orderId, orderApproveDTO, authentication.getName());
 
         return ResponseEntity.ok(null);
+    }
+
+    @GetMapping("/qna")
+    public ResponseEntity<PageResponseDTO> getQnAs(@RequestParam(required = false, defaultValue = "1") int page, Authentication authentication) {
+        if (page < 1) {
+            throw new GlobalException(GlobalExceptionType.PAGE_INDEX_NOT_POSITIVE_NUMBER);
+        }
+
+        PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
+
+        PageResponseDTO pageResponseDTO = qnAService.getQnAsAdmin(pageRequest, authentication.getName());
+
+        return ResponseEntity.ok(pageResponseDTO);
     }
 }

--- a/travel/src/main/java/com/travel/global/config/SecurityConfig.java
+++ b/travel/src/main/java/com/travel/global/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/members", "/login", "/authority", "/reissue", "/logout", "/search/**").permitAll()
                 .antMatchers("/userTest").hasRole("USER")
-                .antMatchers("/adminTest").hasRole("ADMIN")
+                .antMatchers("/adminTest", "/admins/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class);

--- a/travel/src/main/java/com/travel/post/controller/QnAController.java
+++ b/travel/src/main/java/com/travel/post/controller/QnAController.java
@@ -1,8 +1,12 @@
 package com.travel.post.controller;
 
+import com.travel.global.exception.GlobalException;
+import com.travel.global.exception.GlobalExceptionType;
+import com.travel.global.response.PageResponseDTO;
 import com.travel.post.dto.request.QnARequsetDTO;
 import com.travel.post.service.QnAService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class QnAController {
 
+    public static final int PAGE_SIZE = 5;
     private final QnAService qnAService;
 
     @PostMapping
@@ -19,6 +24,18 @@ public class QnAController {
         qnAService.createQnA(qnARequsetDTO, authentication.getName());
 
         return ResponseEntity.ok(null);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponseDTO> getQnAs(@RequestParam(required = false, defaultValue = "1") int page, Authentication authentication) {
+        if (page < 1) {
+            throw new GlobalException(GlobalExceptionType.PAGE_INDEX_NOT_POSITIVE_NUMBER);
+        }
+
+        PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
+        PageResponseDTO pageResponseDTO = qnAService.getQnAs(pageRequest, authentication.getName());
+
+        return ResponseEntity.ok(pageResponseDTO);
     }
 
     @DeleteMapping("/{postId}")

--- a/travel/src/main/java/com/travel/post/controller/QnAController.java
+++ b/travel/src/main/java/com/travel/post/controller/QnAController.java
@@ -3,7 +3,7 @@ package com.travel.post.controller;
 import com.travel.global.exception.GlobalException;
 import com.travel.global.exception.GlobalExceptionType;
 import com.travel.global.response.PageResponseDTO;
-import com.travel.post.dto.request.QnARequsetDTO;
+import com.travel.post.dto.request.QnARequestDTO;
 import com.travel.post.service.QnAService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -20,8 +20,8 @@ public class QnAController {
     private final QnAService qnAService;
 
     @PostMapping
-    public ResponseEntity<Void> createQnA(@RequestBody QnARequsetDTO qnARequsetDTO, Authentication authentication) {
-        qnAService.createQnA(qnARequsetDTO, authentication.getName());
+    public ResponseEntity<Void> createQnA(@RequestBody QnARequestDTO qnARequestDTO, Authentication authentication) {
+        qnAService.createQnA(qnARequestDTO, authentication.getName());
 
         return ResponseEntity.ok(null);
     }

--- a/travel/src/main/java/com/travel/post/dto/request/QnAAnswerRequestDTO.java
+++ b/travel/src/main/java/com/travel/post/dto/request/QnAAnswerRequestDTO.java
@@ -1,0 +1,16 @@
+package com.travel.post.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class QnAAnswerRequestDTO {
+
+    @NotNull
+    private Long postId;
+
+    @NotEmpty
+    private String content;
+}

--- a/travel/src/main/java/com/travel/post/dto/request/QnARequestDTO.java
+++ b/travel/src/main/java/com/travel/post/dto/request/QnARequestDTO.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import javax.validation.constraints.NotEmpty;
 
 @Getter
-public class QnARequsetDTO {
+public class QnARequestDTO {
 
     @NotEmpty
     private String title;

--- a/travel/src/main/java/com/travel/post/dto/response/QnAAdminResponseDTO.java
+++ b/travel/src/main/java/com/travel/post/dto/response/QnAAdminResponseDTO.java
@@ -1,0 +1,27 @@
+package com.travel.post.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class QnAAdminResponseDTO {
+
+    private Long postId;
+
+    private String postTitle;
+
+    private String postContent;
+
+    private String inquiryType;
+
+    private String qnAStatus;
+
+    private String purchasedProductName;
+
+    private LocalDateTime createdDate;
+
+    private String memberName;
+}

--- a/travel/src/main/java/com/travel/post/dto/response/QnAAdminResponseDTO.java
+++ b/travel/src/main/java/com/travel/post/dto/response/QnAAdminResponseDTO.java
@@ -19,6 +19,8 @@ public class QnAAdminResponseDTO {
 
     private String qnAStatus;
 
+    private String answer;
+
     private String purchasedProductName;
 
     private LocalDateTime createdDate;

--- a/travel/src/main/java/com/travel/post/dto/response/QnAResponseDTO.java
+++ b/travel/src/main/java/com/travel/post/dto/response/QnAResponseDTO.java
@@ -19,6 +19,8 @@ public class QnAResponseDTO {
 
     private String qnAStatus;
 
+    private String answer;
+
     private String purchasedProductName;
 
     private LocalDateTime createdDate;

--- a/travel/src/main/java/com/travel/post/dto/response/QnAResponseDTO.java
+++ b/travel/src/main/java/com/travel/post/dto/response/QnAResponseDTO.java
@@ -1,0 +1,25 @@
+package com.travel.post.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class QnAResponseDTO {
+
+    private Long postId;
+
+    private String postTitle;
+
+    private String postContent;
+
+    private String inquiryType;
+
+    private String qnAStatus;
+
+    private String purchasedProductName;
+
+    private LocalDateTime createdDate;
+}

--- a/travel/src/main/java/com/travel/post/entity/AnswerPost.java
+++ b/travel/src/main/java/com/travel/post/entity/AnswerPost.java
@@ -2,6 +2,7 @@ package com.travel.post.entity;
 
 import com.travel.product.entity.PurchasedProduct;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,7 +19,16 @@ public class AnswerPost {
     @Column(name = "answer_id")
     private Long answerId;
 
+    @Column(name = "answer_content")
+    private String answerContent;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private QnAPost qnAPost;
+
+    @Builder
+    public AnswerPost(String answerContent, QnAPost qnAPost) {
+        this.answerContent = answerContent;
+        this.qnAPost = qnAPost;
+    }
 }

--- a/travel/src/main/java/com/travel/post/entity/QnAPost.java
+++ b/travel/src/main/java/com/travel/post/entity/QnAPost.java
@@ -31,24 +31,36 @@ public class QnAPost extends Post {
         this.inquiryType = inquiryType;
     }
 
-    public QnAResponseDTO toQnAResponseDTO() {
+    public QnAResponseDTO toQnAResponseDTO(AnswerPost answerPost) {
+        String answerContent = null;
+        if (answerPost != null) {
+            answerContent = answerPost.getAnswerContent();
+        }
+
         return QnAResponseDTO.builder()
                 .postId(this.getPostId())
                 .postTitle(this.getPostTitle())
                 .postContent(this.getPostContent())
                 .inquiryType(this.getInquiryType().getKorean())
                 .qnAStatus(this.getQnAStatus().getKorean())
+                .answer(answerContent)
                 .createdDate(this.getCreatedDate())
                 .build();
     }
 
-    public QnAAdminResponseDTO toQnAAdminResponseDTO() {
+    public QnAAdminResponseDTO toQnAAdminResponseDTO(AnswerPost answerPost) {
+        String answerContent = null;
+        if (answerPost != null) {
+            answerContent = answerPost.getAnswerContent();
+        }
+
         return QnAAdminResponseDTO.builder()
                 .postId(this.getPostId())
                 .postTitle(this.getPostTitle())
                 .postContent(this.getPostContent())
                 .inquiryType(this.getInquiryType().getKorean())
                 .qnAStatus(this.getQnAStatus().getKorean())
+                .answer(answerContent)
                 .createdDate(this.getCreatedDate())
                 .memberName(this.getMember().getMemberName())
                 .build();

--- a/travel/src/main/java/com/travel/post/entity/QnAPost.java
+++ b/travel/src/main/java/com/travel/post/entity/QnAPost.java
@@ -1,6 +1,8 @@
 package com.travel.post.entity;
 
 import com.travel.member.entity.Member;
+import com.travel.post.dto.response.QnAAdminResponseDTO;
+import com.travel.post.dto.response.QnAResponseDTO;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,9 +26,31 @@ public class QnAPost extends Post {
     @Enumerated(EnumType.STRING)
     private QnAStatus qnAStatus = QnAStatus.WAITING_FOR_ANSWER;
 
-
     public QnAPost(String title, String content, Member member, InquiryType inquiryType) {
         super(title, content, member);
         this.inquiryType = inquiryType;
+    }
+
+    public QnAResponseDTO toQnAResponseDTO() {
+        return QnAResponseDTO.builder()
+                .postId(this.getPostId())
+                .postTitle(this.getPostTitle())
+                .postContent(this.getPostContent())
+                .inquiryType(this.getInquiryType().getKorean())
+                .qnAStatus(this.getQnAStatus().getKorean())
+                .createdDate(this.getCreatedDate())
+                .build();
+    }
+
+    public QnAAdminResponseDTO toQnAAdminResponseDTO() {
+        return QnAAdminResponseDTO.builder()
+                .postId(this.getPostId())
+                .postTitle(this.getPostTitle())
+                .postContent(this.getPostContent())
+                .inquiryType(this.getInquiryType().getKorean())
+                .qnAStatus(this.getQnAStatus().getKorean())
+                .createdDate(this.getCreatedDate())
+                .memberName(this.getMember().getMemberName())
+                .build();
     }
 }

--- a/travel/src/main/java/com/travel/post/entity/QnAProductPost.java
+++ b/travel/src/main/java/com/travel/post/entity/QnAProductPost.java
@@ -26,28 +26,42 @@ public class QnAProductPost extends QnAPost {
         this.purchasedProduct = purchasedProduct;
     }
 
-    public QnAResponseDTO toQnAResponseDTO() {
+    @Override
+    public QnAResponseDTO toQnAResponseDTO(AnswerPost answerPost) {
+        String answerContent = null;
+        if (answerPost != null) {
+            answerContent = answerPost.getAnswerContent();
+        }
+
         return QnAResponseDTO.builder()
                 .postId(this.getPostId())
                 .postTitle(this.getPostTitle())
                 .postContent(this.getPostContent())
                 .inquiryType(this.getInquiryType().getKorean())
                 .qnAStatus(this.getQnAStatus().getKorean())
+                .answer(answerContent)
                 .purchasedProductName(this.getPurchasedProduct().getPurchasedProductName())
                 .createdDate(this.getCreatedDate())
                 .build();
     }
 
-    public QnAAdminResponseDTO toQnAAdminResponseDTO() {
-            return QnAAdminResponseDTO.builder()
-                    .postId(this.getPostId())
-                    .postTitle(this.getPostTitle())
-                    .postContent(this.getPostContent())
-                    .inquiryType(this.getInquiryType().getKorean())
-                    .qnAStatus(this.getQnAStatus().getKorean())
-                    .purchasedProductName(this.getPurchasedProduct().getPurchasedProductName())
-                    .createdDate(this.getCreatedDate())
-                    .memberName(this.getMember().getMemberName())
-                    .build();
+    @Override
+    public QnAAdminResponseDTO toQnAAdminResponseDTO(AnswerPost answerPost) {
+        String answerContent = null;
+        if (answerPost != null) {
+            answerContent = answerPost.getAnswerContent();
         }
+
+        return QnAAdminResponseDTO.builder()
+                .postId(this.getPostId())
+                .postTitle(this.getPostTitle())
+                .postContent(this.getPostContent())
+                .inquiryType(this.getInquiryType().getKorean())
+                .qnAStatus(this.getQnAStatus().getKorean())
+                .answer(answerContent)
+                .purchasedProductName(this.getPurchasedProduct().getPurchasedProductName())
+                .createdDate(this.getCreatedDate())
+                .memberName(this.getMember().getMemberName())
+                .build();
+    }
 }

--- a/travel/src/main/java/com/travel/post/entity/QnAProductPost.java
+++ b/travel/src/main/java/com/travel/post/entity/QnAProductPost.java
@@ -1,6 +1,8 @@
 package com.travel.post.entity;
 
 
+import com.travel.post.dto.response.QnAAdminResponseDTO;
+import com.travel.post.dto.response.QnAResponseDTO;
 import com.travel.product.entity.PurchasedProduct;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,4 +25,29 @@ public class QnAProductPost extends QnAPost {
         super(qnAPost.getPostTitle(), qnAPost.getPostContent(), qnAPost.getMember(), qnAPost.getInquiryType());
         this.purchasedProduct = purchasedProduct;
     }
+
+    public QnAResponseDTO toQnAResponseDTO() {
+        return QnAResponseDTO.builder()
+                .postId(this.getPostId())
+                .postTitle(this.getPostTitle())
+                .postContent(this.getPostContent())
+                .inquiryType(this.getInquiryType().getKorean())
+                .qnAStatus(this.getQnAStatus().getKorean())
+                .purchasedProductName(this.getPurchasedProduct().getPurchasedProductName())
+                .createdDate(this.getCreatedDate())
+                .build();
+    }
+
+    public QnAAdminResponseDTO toQnAAdminResponseDTO() {
+            return QnAAdminResponseDTO.builder()
+                    .postId(this.getPostId())
+                    .postTitle(this.getPostTitle())
+                    .postContent(this.getPostContent())
+                    .inquiryType(this.getInquiryType().getKorean())
+                    .qnAStatus(this.getQnAStatus().getKorean())
+                    .purchasedProductName(this.getPurchasedProduct().getPurchasedProductName())
+                    .createdDate(this.getCreatedDate())
+                    .memberName(this.getMember().getMemberName())
+                    .build();
+        }
 }

--- a/travel/src/main/java/com/travel/post/repository/AnswerRepository.java
+++ b/travel/src/main/java/com/travel/post/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package com.travel.post.repository;
+
+import com.travel.post.entity.AnswerPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<AnswerPost, Long> {
+}

--- a/travel/src/main/java/com/travel/post/repository/AnswerRepository.java
+++ b/travel/src/main/java/com/travel/post/repository/AnswerRepository.java
@@ -1,7 +1,12 @@
 package com.travel.post.repository;
 
 import com.travel.post.entity.AnswerPost;
+import com.travel.post.entity.QnAPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AnswerRepository extends JpaRepository<AnswerPost, Long> {
+
+    Optional<AnswerPost> findByQnAPost(QnAPost qnAPost);
 }

--- a/travel/src/main/java/com/travel/post/repository/QnARepository.java
+++ b/travel/src/main/java/com/travel/post/repository/QnARepository.java
@@ -1,9 +1,14 @@
 package com.travel.post.repository;
 
+import com.travel.member.entity.Member;
 import com.travel.post.entity.QnAPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface QnARepository extends JpaRepository<QnAPost, Long> {
+
+    List<QnAPost> findByMember(Member member);
 }

--- a/travel/src/main/java/com/travel/post/service/QnAService.java
+++ b/travel/src/main/java/com/travel/post/service/QnAService.java
@@ -1,10 +1,14 @@
 package com.travel.post.service;
 
+import com.travel.global.response.PageResponseDTO;
 import com.travel.post.dto.request.QnARequsetDTO;
+import org.springframework.data.domain.Pageable;
 
 public interface QnAService {
 
     void createQnA(QnARequsetDTO qnARequsetDTO, String memberEmail);
+
+    PageResponseDTO getQnAs(Pageable pageable, String memberEmail);
 
     void deleteQnA(Long postId, String memberEmail);
 

--- a/travel/src/main/java/com/travel/post/service/QnAService.java
+++ b/travel/src/main/java/com/travel/post/service/QnAService.java
@@ -12,4 +12,6 @@ public interface QnAService {
 
     void deleteQnA(Long postId, String memberEmail);
 
+    PageResponseDTO getQnAsAdmin(Pageable pageable, String memberEmail);
+
 }

--- a/travel/src/main/java/com/travel/post/service/QnAService.java
+++ b/travel/src/main/java/com/travel/post/service/QnAService.java
@@ -1,12 +1,12 @@
 package com.travel.post.service;
 
 import com.travel.global.response.PageResponseDTO;
-import com.travel.post.dto.request.QnARequsetDTO;
+import com.travel.post.dto.request.QnARequestDTO;
 import org.springframework.data.domain.Pageable;
 
 public interface QnAService {
 
-    void createQnA(QnARequsetDTO qnARequsetDTO, String memberEmail);
+    void createQnA(QnARequestDTO qnARequestDTO, String memberEmail);
 
     PageResponseDTO getQnAs(Pageable pageable, String memberEmail);
 

--- a/travel/src/main/java/com/travel/post/service/QnAService.java
+++ b/travel/src/main/java/com/travel/post/service/QnAService.java
@@ -1,6 +1,7 @@
 package com.travel.post.service;
 
 import com.travel.global.response.PageResponseDTO;
+import com.travel.post.dto.request.QnAAnswerRequestDTO;
 import com.travel.post.dto.request.QnARequestDTO;
 import org.springframework.data.domain.Pageable;
 
@@ -14,4 +15,5 @@ public interface QnAService {
 
     PageResponseDTO getQnAsAdmin(Pageable pageable, String memberEmail);
 
+    void createAnswer(QnAAnswerRequestDTO qnAAnswerRequestDTO, String memberEmail);
 }

--- a/travel/src/main/java/com/travel/post/service/impl/QnAServiceImpl.java
+++ b/travel/src/main/java/com/travel/post/service/impl/QnAServiceImpl.java
@@ -77,14 +77,17 @@ public class QnAServiceImpl implements QnAService {
 
         List<QnAResponseDTO> qnAPostDTOList = qnAPostList.stream()
                 .map(qnAPost -> {
+                    AnswerPost answerPost = answerRepository.findByQnAPost(qnAPost)
+                            .orElse(null);
+
                     QnAProductPost qnAProductPost = qnAProductRepository.findById(qnAPost.getPostId())
                             .orElse(null);
 
                     if (qnAProductPost != null) {
-                        return qnAProductPost.toQnAResponseDTO();
+                        return qnAProductPost.toQnAResponseDTO(answerPost);
                     }
 
-                    return qnAPost.toQnAResponseDTO();
+                    return qnAPost.toQnAResponseDTO(answerPost);
                 })
                 .collect(Collectors.toList());
 
@@ -119,14 +122,17 @@ public class QnAServiceImpl implements QnAService {
 
         List<QnAAdminResponseDTO> qnAPostDTOList = qnAPostList.stream()
                 .map(qnAPost -> {
+                    AnswerPost answerPost = answerRepository.findByQnAPost(qnAPost)
+                                                .orElse(null);
+
                     QnAProductPost qnAProductPost = qnAProductRepository.findById(qnAPost.getPostId())
                             .orElse(null);
 
                     if (qnAProductPost != null) {
-                        return qnAProductPost.toQnAAdminResponseDTO();
+                        return qnAProductPost.toQnAAdminResponseDTO(answerPost);
                     }
 
-                    return qnAPost.toQnAAdminResponseDTO();
+                    return qnAPost.toQnAAdminResponseDTO(answerPost);
                 })
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## Motivation

#78
QnA read 기능 구현

#92
QnA 리스트 조회(관리자용), QnA 답변 생성(관리자용) 기능 구현 

## Key Changes

- Change 1
   - https://github.com/KDT3-Final-6/final-project-BE/issues/81
      - 2af02758bfc29cef235287d960327dbb132856df: 컨트롤러에서 토큰을 받게 수정
- Change 2
  - https://github.com/KDT3-Final-6/final-project-BE/issues/78
     - b12130b7c7b6c9ad4534c0183f71b141fba889ba: QnAResponseDTO 생성
     - f35ad5d845b8e8dfc3fc769016d133b7b482f2a7: QnAResponseDTO 쿼리 메서드 추가
     - 28b61599122525069bd1918a9e7e1d26e7ac199f: QnAService에 qna 리스트 조회 (getQnAs) 기능 구현
     - 94b912995be9ce1a83446fb62a2a811c77eb5463: QnAController에 qna 리스트 조회 (getQnAs) API 구현
- Change 3
   - https://github.com/KDT3-Final-6/final-project-BE/issues/92
      - ff66f2b5b1dd6058991f9fe9cf6cae244978b918: QnAAdminResponseDTO 생성
      - de27434fc16a340c4421c990a6176bcee65263b2: 빌더패턴으로 DTO로 만드는 메서드 생성
      - 94c10fc99bb462b492918ece6ae487402233f346: QnAService에 qna 리스트 조회(관리자용) (getQnAsAdmin) 기능 구현
      - cd799b7c204adfa9acbd9b0a6725229a3360d23b: AdminController에 qna 리스트 조회(관리자용) (getQnA) API 구현
      - ace1a96a157c8c1944aaa51dcdae0f7c708f6ba6: QnAAnswerRequestDTO 생성
      - ef8a887366e14785bd8aeec58ae83b456f8c548a: QnAService에 qna 답변 작성 (createAnswer) 기능 구현
      - 9d5b6899bc5ad36fb487399b25aa07ca41e3ba04: AdminController에 qna 답변 작성 (createAnswer) API 구현
      - 6744d8bed6b7997e2fe171668b71a4926eb0a1e0: AnswerRepository 생성
      - 45e57879fd76cb5a7446c802ef45b432f05dc0e8: qna 리스트 조회 ResponseDTO 수정
- Change 4
   - 기타  
      - 883368b2af705de36f3a258057548f94ecc9e26a: 어드민 전용 api 추가
      - 50fade4772be1b34c8776cefc1756525730dfd30: QnARequsetDTO -> QnARequestDTO로 이름 변경

## To reviewers

QnA api는 끝입니다.

