### PR TITLE
Feat/password check, hobby

### DIFF
--- a/travel/src/main/java/com/travel/auth/controller/AuthController.java
+++ b/travel/src/main/java/com/travel/auth/controller/AuthController.java
@@ -46,22 +46,12 @@ public class AuthController {
         return memberService.reissue(reissue);
     }
 
-        @PostMapping("/logout")
-    public ResponseDto<? extends Object> logout(@Validated @RequestBody MemberRequestDto.Logout logout, Errors errors) {
-        // validation check
-        if (errors.hasErrors()) {
-            return new ResponseDto<>(Helper.refineErrors(errors));
-        }
-        return memberService.logout(logout);
+    @PostMapping("/members/logout")
+    public ResponseEntity<?> logout(@Validated @RequestHeader(name = "Authorization") String token,
+                                    @RequestHeader(name = "Refresh-Token")String refreshToken) {
+        // 토큰 폐기 등 로그아웃 처리 수행
+        return ResponseEntity.ok("로그아웃 성공");
     }
-//    @PostMapping("/logout")
-//    public ResponseEntity<?> logout(@Validated @RequestHeader(name = "Authorization") String token,
-//                                    @RequestBody MemberRequestDto.Logout logout) {
-//        // 토큰 폐기 등 로그아웃 처리 수행
-//        return memberService.logout(logout);
-//    }
-
-
     @GetMapping("/authority")
     public ResponseDto<?> authority() {
         log.info("ADD ROLE_ADMIN");

--- a/travel/src/main/java/com/travel/auth/controller/AuthController.java
+++ b/travel/src/main/java/com/travel/auth/controller/AuthController.java
@@ -53,7 +53,7 @@ public class AuthController {
         return ResponseEntity.ok("로그아웃 성공");
     }
     @GetMapping("/authority")
-    public ResponseDto<?> authority() {
+    public ResponseEntity<?> authority() {
         log.info("ADD ROLE_ADMIN");
         return memberService.authority();
     }

--- a/travel/src/main/java/com/travel/auth/dto/request/MemberRequestDto.java
+++ b/travel/src/main/java/com/travel/auth/dto/request/MemberRequestDto.java
@@ -9,6 +9,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import java.util.List;
 
 public class MemberRequestDto {
 
@@ -31,14 +32,13 @@ public class MemberRequestDto {
         private String memberNickname;
 
         @NotEmpty(message = "휴대폰 번호를 작성해주세요")
-//        @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "000-0000-0000 으로 작성해주세요")
         @Pattern(regexp = "^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$", message = "-없이 작성해주세요")
         private String memberPhone;
 
         @NotEmpty(message = "생일을 적어주세요")
         @Pattern(regexp = "^([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))$", message = "YYYY-MM-DD 으로 작성해주세요")
         private String memberBirthDate;
-        private Hobby memberHobby;
+        private List<Hobby> memberHobby;
         private String memberGender;
 
     }

--- a/travel/src/main/java/com/travel/auth/service/MemberService.java
+++ b/travel/src/main/java/com/travel/auth/service/MemberService.java
@@ -27,8 +27,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -50,6 +53,7 @@ public class MemberService {
 
         MemberImage defaultImage = MemberImage.CreateDefaultMemberImage();
 
+
         Member member = Member.builder()
                 .memberEmail(signUp.getMemberEmail())
                 .memberPassword(passwordEncoder.encode(signUp.getMemberPassword()))
@@ -57,7 +61,7 @@ public class MemberService {
                 .memberNickname(signUp.getMemberNickname())
                 .memberPhone(signUp.getMemberPhone())
                 .memberBirthDate(signUp.getMemberBirthDate())
-                .memberHobby(Hobby.valueOf(signUp.getMemberHobby().toString()))
+                .memberHobby(signUp.getMemberHobby())
                 .memberGender(signUp.getMemberGender())
                 .roles(Collections.singletonList(Authority.ROLE_USER.name()))
                 .build();

--- a/travel/src/main/java/com/travel/auth/service/MemberService.java
+++ b/travel/src/main/java/com/travel/auth/service/MemberService.java
@@ -145,8 +145,7 @@ public class MemberService {
         return new ResponseDto<>(HttpStatus.OK);
     }
 
-    public ResponseDto<?> authority() {
-        // SecurityContext에 담겨 있는 authentication userEamil 정보
+    public ResponseEntity<?> authority() {
         String memberEmail = SecurityUtil.getCurrentUserEmail();
 
         Member member = memberRepository.findByMemberEmail(memberEmail)
@@ -156,7 +155,7 @@ public class MemberService {
         member.getRoles().add(Authority.ROLE_ADMIN.name());
         memberRepository.save(member);
 
-        return new ResponseDto<>(ResponseDto.empty());
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     public boolean checkToken(String token) {

--- a/travel/src/main/java/com/travel/global/config/SecurityConfig.java
+++ b/travel/src/main/java/com/travel/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(HttpMethod.POST, "/members").permitAll()
                 .antMatchers("/login", "/reissue", "/members/logout", "/search/**", "/non-members/**", "/products/**").permitAll()
-                .antMatchers("/carts/**", "/members", "/orders/**", "/qna/**", "/wishlist/**").hasRole("USER")
+                .antMatchers("/carts/**", "/members", "/orders/**", "/qna/**", "/wishlist/**","/members/password-check").hasRole("USER")
                 .antMatchers("/admins/**","/authority/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
                 .and()

--- a/travel/src/main/java/com/travel/global/config/SecurityConfig.java
+++ b/travel/src/main/java/com/travel/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/members", "/login", "/authority", "/reissue", "/logout", "/search/**").permitAll()
+                .antMatchers("/members", "/login", "/authority", "/reissue", "/members/logout", "/search/**").permitAll()
                 .antMatchers("/userTest").hasRole("USER")
                 .antMatchers("/adminTest", "/admins/**").hasRole("ADMIN")
                 .anyRequest().authenticated()

--- a/travel/src/main/java/com/travel/member/controller/MemberController.java
+++ b/travel/src/main/java/com/travel/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.travel.auth.dto.request.MemberRequestDto;
 import com.travel.auth.jwt.JwtTokenProvider;
 import com.travel.member.dto.requestDTO.DeleteMemberDTO;
 import com.travel.member.dto.requestDTO.MemberModifyRequestDTO;
+import com.travel.member.dto.requestDTO.PasswordCheckDTO;
 import com.travel.member.dto.responseDTO.MemberResponseDTO;
 import com.travel.member.entity.Member;
 import com.travel.member.service.MemberService;
@@ -70,7 +71,7 @@ public class MemberController {
         return memberService.exampleOfUpdate(memberEmail,modifyMemberRequestDTO);
     }
 
-        @DeleteMapping("/members")
+    @DeleteMapping("/members")
     public ResponseEntity<?> deleteMember(@RequestHeader("Authorization") String authorizationHeader,
                                                        @RequestBody DeleteMemberDTO deleteMemberDTO) {
             String token = authorizationHeader.substring(7);
@@ -83,35 +84,24 @@ public class MemberController {
             return memberService.deleteMember(memberEmail, deleteMemberDTO);
         }
 
-//    @DeleteMapping("/members")
-//    public ResponseEntity<ResponseDto<?>> deleteMember(@RequestHeader("Authorization") String authorizationHeader,
-//                                                       @RequestBody DeleteMemberDTO deleteMemberDTO) {
-//        String token = authorizationHeader.substring(7);
-//        Claims claims = Jwts.parserBuilder()
-//                .setSigningKey(tokenProvider.getKey())
-//                .build()
-//                .parseClaimsJws(token)
-//                .getBody();
-//        String memberEmail = claims.getSubject();
-//
-//        DeleteMemberDTO delete = new DeleteMemberDTO();
-//        delete.setMemberEmail(memberEmail);
-//        delete.setMemberPassword(deleteMemberDTO.getMemberPassword());
-//
-//        boolean isDeleted = memberService.deleteMember(delete);
-//
-//        if (isDeleted) {
-//            ResponseDto<?> responseDto = new ResponseDto<>("success");
-//            return ResponseEntity.ok(responseDto);
-//        } else {
-//            ResponseDto<?> responseDto = new ResponseDto<>("회원 삭제에 실패하였습니다.");
-//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(responseDto);
-//        }
-//    }
+    @PostMapping("/members/password-check")
+    public Boolean passwordCheck(@RequestHeader("Authorization") String authorizationHeader,
+                                           @RequestBody PasswordCheckDTO passwordCheckDTO) {
+        String token = authorizationHeader.substring(7);
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(tokenProvider.getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        String memberEmail = claims.getSubject();
+        return memberService.passwordCheck(memberEmail, passwordCheckDTO);
+
+    }
+
 
     @PutMapping("/members/profile")
     public ResponseEntity<String> putProfile(@RequestHeader("Authorization") String authorizationHeader,
-                                             @RequestPart("profile") MultipartFile profile) throws IOException{
+                                             @RequestPart("profile") MultipartFile profile) throws IOException {
 
         String token = authorizationHeader.substring(7);
         Claims claims = Jwts.parserBuilder()

--- a/travel/src/main/java/com/travel/member/dto/requestDTO/MemberModifyRequestDTO.java
+++ b/travel/src/main/java/com/travel/member/dto/requestDTO/MemberModifyRequestDTO.java
@@ -9,6 +9,7 @@ import lombok.*;
 
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import java.util.List;
 
 public class MemberModifyRequestDTO {
 
@@ -27,7 +28,7 @@ public class MemberModifyRequestDTO {
         private String memberName;
         @Size(min = 2, max = 10, message = "2글자 이상 10글자 이하로 입력해주세요")
         private String memberNickname;
-        private Hobby memberHobby;
+        private List<Hobby> memberHobby;
         @Pattern(regexp = "^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$", message = "-없이 작성해주세요")
         private String memberPhone;
         private Boolean memberSmsAgree;

--- a/travel/src/main/java/com/travel/member/dto/requestDTO/PasswordCheckDTO.java
+++ b/travel/src/main/java/com/travel/member/dto/requestDTO/PasswordCheckDTO.java
@@ -1,0 +1,20 @@
+package com.travel.member.dto.requestDTO;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@Setter
+public class PasswordCheckDTO {
+    private String MemberPassword;
+
+    public String getMemberPassword() {
+        return MemberPassword;
+    }
+
+    public void setMemberPassword(String memberPassword) {
+        MemberPassword = memberPassword;
+    }
+}

--- a/travel/src/main/java/com/travel/member/dto/responseDTO/MemberResponseDTO.java
+++ b/travel/src/main/java/com/travel/member/dto/responseDTO/MemberResponseDTO.java
@@ -5,6 +5,8 @@ import com.travel.member.entity.Hobby;
 import com.travel.member.entity.Member;
 import lombok.*;
 
+import java.util.List;
+
 public class MemberResponseDTO {
 
     @Getter
@@ -19,7 +21,7 @@ public class MemberResponseDTO {
         private String memberNickName;
         private String memberPhone;
         private String memberBirthDate;
-        private Hobby memberHobby;
+        private List<Hobby> memberHobby;
         private Boolean memberSmsAgree;
         private Boolean memberEmailAgree;
         private Grade memberGrade;
@@ -59,7 +61,7 @@ public class MemberResponseDTO {
             return memberBirthDate;
         }
 
-        public Hobby getMemberHobby() {
+        public List<Hobby> getMemberHobby() {
             return memberHobby;
         }
         public Boolean getMemberSmsAgree() {

--- a/travel/src/main/java/com/travel/member/entity/Hobby.java
+++ b/travel/src/main/java/com/travel/member/entity/Hobby.java
@@ -1,17 +1,19 @@
 package com.travel.member.entity;
 
 public enum Hobby {
-    FISHING("낚시"),
     SHOPPING("쇼핑"),
     GOLF("골프"),
     WINE("와인"),
     VOLUNTEER("봉사활동"),
-    TREKKING("트레킹");
-
+    TREKKING("트레킹"),
+    CULTURE("문화탐방"),
+    PILGRIMAGE("성지순례");
 
     String korean;
 
     Hobby(String korean) {
         this.korean = korean;
     }
+
+
 }

--- a/travel/src/main/java/com/travel/member/entity/Member.java
+++ b/travel/src/main/java/com/travel/member/entity/Member.java
@@ -60,8 +60,10 @@ public class Member extends BaseEntityWithModifiedDate implements UserDetails {
     private Boolean memberDeleteCheck = false;
 
     @Column(name = "member_hobby")
+    @ElementCollection(fetch = FetchType.LAZY)
     @Enumerated(EnumType.STRING)
-    private Hobby memberHobby;
+    private List<Hobby> memberHobby;
+
     @Column(name = "member_gender")
     private String memberGender;
     @Column(name = "member_smsAgree", nullable = false)
@@ -73,7 +75,7 @@ public class Member extends BaseEntityWithModifiedDate implements UserDetails {
     private MemberImage memberImage;
 
     @Column
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @Builder.Default
     private List<String> roles = new ArrayList<>();
     @OneToMany(mappedBy = "member")
@@ -103,7 +105,7 @@ public class Member extends BaseEntityWithModifiedDate implements UserDetails {
 
     // 회원가입 입력
     @Builder
-    public Member(String memberEmail, String memberPassword, String memberName, String memberNickname, String memberPhone, String memberBirthDate, Hobby memberHobby, List<String> roles, String memberGender) {
+    public Member(String memberEmail, String memberPassword, String memberName, String memberNickname, String memberPhone, String memberBirthDate, List<Hobby> memberHobby, List<String> roles, String memberGender) {
         this.memberEmail = memberEmail;
         this.memberPassword = memberPassword;
         this.memberName = memberName;

--- a/travel/src/main/java/com/travel/member/service/MemberService.java
+++ b/travel/src/main/java/com/travel/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.travel.auth.dto.ResponseDto;
 import com.travel.auth.dto.request.MemberRequestDto;
 import com.travel.member.dto.requestDTO.DeleteMemberDTO;
 import com.travel.member.dto.requestDTO.MemberModifyRequestDTO;
+import com.travel.member.dto.requestDTO.PasswordCheckDTO;
 import com.travel.member.dto.responseDTO.MemberResponseDTO;
 import com.travel.member.entity.Member;
 import org.springframework.http.ResponseEntity;
@@ -16,11 +17,11 @@ public interface MemberService {
     ResponseDto<?> memberInfo(MemberRequestDto.Login login);
     Member getMemberById(Long id);
     ResponseEntity<MemberResponseDTO.MemberInfoResponseDTO> getMemberByMemberEmail(String email);
-//    Boolean deleteMember(DeleteMemberDTO delete);
     ResponseDto<?> modifyMember(MemberRequestDto.Login login, MemberModifyRequestDTO.ModifyMemberRequestDTO modifyMemberInfoRequestDTO);
     void updateProfile(String memberEmail, MultipartFile profile) throws IOException;
 
     ResponseEntity<?> exampleOfUpdate(String email,MemberModifyRequestDTO.ModifyMemberRequestDTO dto);
 
     ResponseEntity<?> deleteMember(String email, DeleteMemberDTO deleteMemberDTO);
+    Boolean passwordCheck(String email, PasswordCheckDTO passwordCheckDTO);
 }

--- a/travel/src/main/java/com/travel/member/service/impl/MemberServiceImpl.java
+++ b/travel/src/main/java/com/travel/member/service/impl/MemberServiceImpl.java
@@ -8,6 +8,7 @@ import com.travel.image.repository.MemberImageRepository;
 import com.travel.image.service.FileUploadService;
 import com.travel.member.dto.requestDTO.DeleteMemberDTO;
 import com.travel.member.dto.requestDTO.MemberModifyRequestDTO;
+import com.travel.member.dto.requestDTO.PasswordCheckDTO;
 import com.travel.member.dto.responseDTO.MemberResponseDTO;
 import com.travel.member.entity.Member;
 import com.travel.member.exception.MemberException;
@@ -15,9 +16,12 @@ import com.travel.member.exception.MemberExceptionType;
 import com.travel.member.repository.MemberRepository;
 import com.travel.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -148,24 +152,27 @@ public class MemberServiceImpl implements MemberService {
     }
 
 //    @Override
-//    public Boolean deleteMember(DeleteMemberDTO delete) {
+//    public Boolean passwordCheck(String email, PasswordCheckDTO passwordCheckDTO) {
 //        try {
-//            Member member = memberRepository.findByMemberEmail(delete.getMemberEmail())
-//                    .orElseThrow(() -> new IllegalArgumentException("해당 이메일 주소로 가입한 회원이 존재하지 않습니다."));
-//
-//            // 비밀번호 일치 여부 확인
-//            if (!passwordEncoder.matches(delete.getMemberPassword(), member.getPassword())) {
-//                throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-//            }
-//
-//            member.setMemberDeleteCheck(true);
-//            memberRepository.save(member);
+//            memberRepository.findByMemberEmail(email).orElseThrow(NoSuchElementException::new);
+//            passwordCheckDTO.setMemberPassword(encodingPassword(passwordCheckDTO.getMemberPassword()));
 //            return true;
-//        } catch (IllegalArgumentException e) {
+//        } catch (NoSuchElementException e) {
 //            return false;
 //        }
 //    }
 
+    @Override
+    public Boolean passwordCheck(String email, PasswordCheckDTO passwordCheckDTO) {
+        Optional<Member> memberOptional = memberRepository.findByMemberEmail(email);
+        if (memberOptional.isPresent()) {
+            Member member = memberOptional.get();
+            if (passwordEncoder.matches(passwordCheckDTO.getMemberPassword(), member.getPassword())) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     private void passwordCheck(String checkMemberPassword, String memberPassword) {
         if (!passwordEncoder.matches(checkMemberPassword, memberPassword)) {


### PR DESCRIPTION
## Motivation

#99
hobby 복수 선택 가능하게끔 수정했습니다. 이와 관련된 api 수정
#106 
비밀번호 check 와 authorty 리펙토링


## Key Changes

작업한 내용의 주요 변경사항을 자세히 나열하세요

- Change 1
  - 2181773039c6747b9365c2d1388cb462eaa96eda: logout 경로 변경했습니다.
- Change 2
  - 0d595bc953adea7ea9eae7ee2889ed96886f0087, 82ac7de65b6f3591d7e6575508b4721719fe5d77, d86aece4b3bfc7b9e539b522e953daf5f3b936ac: 회원가입 취미 단수 -> 복수 선택 수정
  -  cf52b77f6fe4e18b79ace2c508758c38016a6ecf: 회원 수정에서도 복수 선택 가능
- Change 3
  - 29298890d882753a66bee3cdb2fd66172c51d490: 취미 목록 변경   
- Change 4
  - 2d601a0da055e825728f59124c8b0a92394f22b1: authority (ResponseDTO -> ResponseEntity 로 변경) 
- Change 5
  - 75af45769f6c5ba149d8ab6bc9750a0ed6502c5f: 비밀번호확인 controller
  - f1c9fcdcc6fa0b3c2d33b65672f5839cb5ffcf49: 비밀번호 확인 dto
  - e5f6ef5003d08f5c54ffeb799a7af3eb5ab50419, 75db2a174372be4c431fec18bc50630a843eb075: service
  - 19740149255397b52acaf9c78fd2c5c918a96374: secret config 에 비밀번호 체크 url 추가


## To reviewers



