### PR TITLE
bug: 카테고리 검색에서 정렬 기준없애면 500에러뜨는 현상 해결

### DIFF
--- a/travel/src/main/java/com/travel/search/service/impl/SearchServiceImpl.java
+++ b/travel/src/main/java/com/travel/search/service/impl/SearchServiceImpl.java
@@ -56,10 +56,10 @@ public class SearchServiceImpl implements SearchService {
                 .filter(product -> product.getProductStatus() == Status.FORSALE)
                 .collect(Collectors.toList());
 
-        if (sortTarget.equals("인기순")) {
-            productList = productList.stream()
-                    .sorted(Comparator.comparing(Product::getWishlistCount).reversed())
-                    .collect(Collectors.toList());
+        if (sortTarget != null && (sortTarget.equals("인기순"))) {
+                productList = productList.stream()
+                        .sorted(Comparator.comparing(Product::getWishlistCount).reversed())
+                        .collect(Collectors.toList());
         }
 
         List<SearchResultResponseDTO> searchResult = productList.stream()


### PR DESCRIPTION
## Motivation

#111 
카테고리 검색 로직에서 sortTarget이 null일 경우를 체크

## Key Changes

- Change 1
  - https://github.com/KDT3-Final-6/final-project-BE/issues/111
     -  47e1e64ec31659f3d0312a7bb14ad4390785ff6c: 카테고리 검색 로직에서 sortTarget이 null일 경우를 체크

## To reviewers



