### PR TITLE
Feature/post QnA 리스트 ResponseDTO에 답변 달린 날짜 필드, 전체 후기 리스트 조회 ResponseDTO에 멤버 닉네임 필드추가

### DIFF
--- a/travel/src/main/java/com/travel/post/dto/response/QnAAdminResponseDTO.java
+++ b/travel/src/main/java/com/travel/post/dto/response/QnAAdminResponseDTO.java
@@ -21,6 +21,8 @@ public class QnAAdminResponseDTO {
 
     private String answer;
 
+    private LocalDateTime replyDate;
+
     private String purchasedProductName;
 
     private LocalDateTime createdDate;

--- a/travel/src/main/java/com/travel/post/dto/response/QnAResponseDTO.java
+++ b/travel/src/main/java/com/travel/post/dto/response/QnAResponseDTO.java
@@ -21,6 +21,8 @@ public class QnAResponseDTO {
 
     private String answer;
 
+    private LocalDateTime replyDate;
+
     private String purchasedProductName;
 
     private LocalDateTime createdDate;

--- a/travel/src/main/java/com/travel/post/dto/response/ReviewListDTO.java
+++ b/travel/src/main/java/com/travel/post/dto/response/ReviewListDTO.java
@@ -17,6 +17,8 @@ public class ReviewListDTO {
 
     private String purchasedProductThumbnail;
 
+    private String memberNickname;
+
     private String postContent;
 
     private int scope;

--- a/travel/src/main/java/com/travel/post/entity/AnswerPost.java
+++ b/travel/src/main/java/com/travel/post/entity/AnswerPost.java
@@ -1,5 +1,6 @@
 package com.travel.post.entity;
 
+import com.travel.global.entity.BaseEntityWithModifiedDate;
 import lombok.*;
 
 import javax.persistence.*;
@@ -8,7 +9,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "answer_post")
-public class AnswerPost {
+public class AnswerPost extends BaseEntityWithModifiedDate {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/travel/src/main/java/com/travel/post/entity/QnAPost.java
+++ b/travel/src/main/java/com/travel/post/entity/QnAPost.java
@@ -54,8 +54,10 @@ public class QnAPost extends Post {
 
     public QnAAdminResponseDTO toQnAAdminResponseDTO(AnswerPost answerPost) {
         String answerContent = null;
+        LocalDateTime answerModifiedDate = null;
         if (answerPost != null) {
             answerContent = answerPost.getAnswerContent();
+            answerModifiedDate = answerPost.getModifiedDate();
         }
 
         return QnAAdminResponseDTO.builder()
@@ -65,6 +67,7 @@ public class QnAPost extends Post {
                 .inquiryType(this.getInquiryType().getKorean())
                 .qnAStatus(this.getQnAStatus().getKorean())
                 .answer(answerContent)
+                .replyDate(answerModifiedDate)
                 .createdDate(this.getCreatedDate())
                 .memberName(this.getMember().getMemberName())
                 .build();

--- a/travel/src/main/java/com/travel/post/entity/QnAPost.java
+++ b/travel/src/main/java/com/travel/post/entity/QnAPost.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -33,8 +34,10 @@ public class QnAPost extends Post {
 
     public QnAResponseDTO toQnAResponseDTO(AnswerPost answerPost) {
         String answerContent = null;
+        LocalDateTime answerModifiedDate = null;
         if (answerPost != null) {
             answerContent = answerPost.getAnswerContent();
+            answerModifiedDate = answerPost.getModifiedDate();
         }
 
         return QnAResponseDTO.builder()
@@ -44,6 +47,7 @@ public class QnAPost extends Post {
                 .inquiryType(this.getInquiryType().getKorean())
                 .qnAStatus(this.getQnAStatus().getKorean())
                 .answer(answerContent)
+                .replyDate(answerModifiedDate)
                 .createdDate(this.getCreatedDate())
                 .build();
     }

--- a/travel/src/main/java/com/travel/post/entity/QnAProductPost.java
+++ b/travel/src/main/java/com/travel/post/entity/QnAProductPost.java
@@ -52,8 +52,10 @@ public class QnAProductPost extends QnAPost {
     @Override
     public QnAAdminResponseDTO toQnAAdminResponseDTO(AnswerPost answerPost) {
         String answerContent = null;
+        LocalDateTime answerModifiedDate = null;
         if (answerPost != null) {
             answerContent = answerPost.getAnswerContent();
+            answerModifiedDate = answerPost.getModifiedDate();
         }
 
         return QnAAdminResponseDTO.builder()
@@ -63,6 +65,7 @@ public class QnAProductPost extends QnAPost {
                 .inquiryType(this.getInquiryType().getKorean())
                 .qnAStatus(this.getQnAStatus().getKorean())
                 .answer(answerContent)
+                .replyDate(answerModifiedDate)
                 .purchasedProductName(this.getPurchasedProduct().getPurchasedProductName())
                 .createdDate(this.getCreatedDate())
                 .memberName(this.getMember().getMemberName())

--- a/travel/src/main/java/com/travel/post/entity/QnAProductPost.java
+++ b/travel/src/main/java/com/travel/post/entity/QnAProductPost.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,8 +30,10 @@ public class QnAProductPost extends QnAPost {
     @Override
     public QnAResponseDTO toQnAResponseDTO(AnswerPost answerPost) {
         String answerContent = null;
+        LocalDateTime answerModifiedDate = null;
         if (answerPost != null) {
             answerContent = answerPost.getAnswerContent();
+            answerModifiedDate = answerPost.getModifiedDate();
         }
 
         return QnAResponseDTO.builder()
@@ -40,6 +43,7 @@ public class QnAProductPost extends QnAPost {
                 .inquiryType(this.getInquiryType().getKorean())
                 .qnAStatus(this.getQnAStatus().getKorean())
                 .answer(answerContent)
+                .replyDate(answerModifiedDate)
                 .purchasedProductName(this.getPurchasedProduct().getPurchasedProductName())
                 .createdDate(this.getCreatedDate())
                 .build();

--- a/travel/src/main/java/com/travel/post/entity/ReviewPost.java
+++ b/travel/src/main/java/com/travel/post/entity/ReviewPost.java
@@ -39,6 +39,7 @@ public class ReviewPost extends Post {
                 .productId(this.purchasedProduct.getProduct().getProductId())
                 .purchasedProductName(this.purchasedProduct.getPurchasedProductName())
                 .purchasedProductThumbnail(this.purchasedProduct.getPurchasedProductThumbnail())
+                .memberNickname(this.getMember().getMemberNickname())
                 .postContent(this.getPostContent())
                 .scope(this.scope)
                 .modifiedDate(this.getModifiedDate().toLocalDate())


### PR DESCRIPTION
## Motivation

#127 
전체 후기 리스트 조회 ResponseDTO에 멤버 닉네임 추가

#128 
QnA 리스트 ResponseDTO에 답변 달린 날짜 필드 추가

## Key Changes

- Change 1
  - https://github.com/KDT3-Final-6/final-project-BE/issues/127
     - 49c0248b007a4f7a20cd0556148d17eb686bec03: 전체 후기 리스트 조회 ResponseDTO에 멤버 닉네임 필드 추가
- Change 2
   - https://github.com/KDT3-Final-6/final-project-BE/issues/128
      - f0efa90ea0fe993c76add10f140a5d5a6b4270a6: QnA 리스트 ResponseDTO에 답변 달린 날짜 필드 추가
      - 74af0edb9cbe6d6194f8a310da7468cdde3012c1: QnA 리스트(관리자용) ResponseDTO에 답변 달린 날짜 필드 추가

## To reviewers

AnswerPost 엔티티에 수정일과 생성일 필드 추가했습니다. db 업데이트 부탁드립니다.

