### PR TITLE
Feat/review 삭제된 리뷰는 리스트 출력에서 제외 시키는 로직, 구매한 상품의 Review 생성을 하나만 할 수 있도록 로직 추가

### DIFF
--- a/travel/src/main/java/com/travel/order/repository/OrderRepository.java
+++ b/travel/src/main/java/com/travel/order/repository/OrderRepository.java
@@ -14,4 +14,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByMember(Member member);
 
     Optional<Order> findByOrderIdAndMember(Long orderId, Member member);
+
+    boolean existsByPurchasedProductsContainsAndMember(PurchasedProduct purchasedProducts, Member member);
 }

--- a/travel/src/main/java/com/travel/post/exception/PostExceptionType.java
+++ b/travel/src/main/java/com/travel/post/exception/PostExceptionType.java
@@ -9,7 +9,8 @@ public enum PostExceptionType implements CustomExceptionType {
 
     INQUIRTY_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 문의 유형입니다."),
     PRODUCT_INQUIRY_REQUIRES_PRODUCT_NUM(HttpStatus.CONFLICT, "상품문의는 상품 번호가 필요합니다."),
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 포스트입니다.");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 포스트입니다."),
+    NOT_THE_PRODUCT_ORDERED(HttpStatus.CONFLICT, "주문한 상품이 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMsg;

--- a/travel/src/main/java/com/travel/post/exception/PostExceptionType.java
+++ b/travel/src/main/java/com/travel/post/exception/PostExceptionType.java
@@ -10,7 +10,8 @@ public enum PostExceptionType implements CustomExceptionType {
     INQUIRTY_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 문의 유형입니다."),
     PRODUCT_INQUIRY_REQUIRES_PRODUCT_NUM(HttpStatus.CONFLICT, "상품문의는 상품 번호가 필요합니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 포스트입니다."),
-    NOT_THE_PRODUCT_ORDERED(HttpStatus.CONFLICT, "주문한 상품이 아닙니다.");
+    NOT_THE_PRODUCT_ORDERED(HttpStatus.CONFLICT, "주문한 상품이 아닙니다."),
+    CAN_ONLY_WRITE_ONE_REVIEW(HttpStatus.CONFLICT, "리뷰는 하나만 작성할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMsg;

--- a/travel/src/main/java/com/travel/post/service/impl/ReviewServiceImpl.java
+++ b/travel/src/main/java/com/travel/post/service/impl/ReviewServiceImpl.java
@@ -7,6 +7,7 @@ import com.travel.member.entity.Member;
 import com.travel.member.exception.MemberException;
 import com.travel.member.exception.MemberExceptionType;
 import com.travel.member.repository.MemberRepository;
+import com.travel.order.repository.OrderRepository;
 import com.travel.post.dto.request.ReviewCreateRequestDTO;
 import com.travel.post.dto.request.ReviewUpdateRequestDTO;
 import com.travel.post.dto.response.ReviewListDTO;
@@ -42,6 +43,7 @@ public class ReviewServiceImpl implements ReviewService {
     private final MemberRepository memberRepository;
     private final PurchasedProductRepository purchasedProductRepository;
     private final ProductRepository productRepository;
+    private final OrderRepository orderRepository;
 
     @Override
     public void createReview(ReviewCreateRequestDTO reviewCreateRequestDTO, String memberEmail) {
@@ -50,6 +52,10 @@ public class ReviewServiceImpl implements ReviewService {
 
         PurchasedProduct purchasedProduct = purchasedProductRepository.findById(reviewCreateRequestDTO.getPurchasedProductId())
                 .orElseThrow(() -> new ProductException(ProductExceptionType.PRODUCT_NOT_FOUND));
+
+        if (!orderRepository.existsByPurchasedProductsContainsAndMember(purchasedProduct, member)) {
+            throw new PostException(PostExceptionType.NOT_THE_PRODUCT_ORDERED);
+        }
 
         ReviewPost reviewPost = new ReviewPost(purchasedProduct.getPurchasedProductName(), reviewCreateRequestDTO.getContent(), member, purchasedProduct, reviewCreateRequestDTO.getScope());
 

--- a/travel/src/main/java/com/travel/post/service/impl/ReviewServiceImpl.java
+++ b/travel/src/main/java/com/travel/post/service/impl/ReviewServiceImpl.java
@@ -59,6 +59,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     public PageResponseDTO getReviews(Pageable pageable) {
         List<ReviewPost> reviewPostList = reviewRepository.findAll().stream()
+                .filter(reviewPost -> !reviewPost.isCanceled())
                 .sorted(Comparator.comparing(ReviewPost::getPostId).reversed())
                 .collect(Collectors.toList());
 
@@ -81,6 +82,7 @@ public class ReviewServiceImpl implements ReviewService {
                 .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
 
         List<ReviewPost> reviewPostList = reviewRepository.findByMember(member).stream()
+                .filter(reviewPost -> !reviewPost.isCanceled())
                 .sorted(Comparator.comparing(ReviewPost::getPostId).reversed())
                 .collect(Collectors.toList());
 
@@ -103,6 +105,7 @@ public class ReviewServiceImpl implements ReviewService {
                 .orElseThrow(() -> new ProductException(ProductExceptionType.PRODUCT_NOT_FOUND));
 
         List<ReviewPost> reviewPostList = reviewRepository.findByPurchasedProductProduct(product).stream()
+                .filter(reviewPost -> !reviewPost.isCanceled())
                 .sorted(Comparator.comparing(ReviewPost::getPostId).reversed())
                 .collect(Collectors.toList());
 

--- a/travel/src/main/java/com/travel/post/service/impl/ReviewServiceImpl.java
+++ b/travel/src/main/java/com/travel/post/service/impl/ReviewServiceImpl.java
@@ -55,6 +55,8 @@ public class ReviewServiceImpl implements ReviewService {
 
         if (!orderRepository.existsByPurchasedProductsContainsAndMember(purchasedProduct, member)) {
             throw new PostException(PostExceptionType.NOT_THE_PRODUCT_ORDERED);
+        } else if (reviewRepository.existsByPurchasedProduct(purchasedProduct)) {
+            throw new PostException(PostExceptionType.CAN_ONLY_WRITE_ONE_REVIEW);
         }
 
         ReviewPost reviewPost = new ReviewPost(purchasedProduct.getPurchasedProductName(), reviewCreateRequestDTO.getContent(), member, purchasedProduct, reviewCreateRequestDTO.getScope());


### PR DESCRIPTION
## Motivation

#165 
삭제된 리뷰는 리스트 출력에서 제외 시키는 로직 추가

#163 
구매한 상품의 Review 생성을 하나만 할 수 있도록 로직 추가

## Key Changes

- Change 1
  - https://github.com/KDT3-Final-6/final-project-BE/issues/165
     - 245aec4c2b359d7cdb8c18f0e8fe9b7f822aec1c:  삭제된 리뷰는 리스트 출력에서 제외 시키는 로직 추가
- Change 2
   - https://github.com/KDT3-Final-6/final-project-BE/issues/163
      - f46807718859f25ee0a2978562bf84ade3bb339d: OrderRepository에 쿼리 메서드 추가
      - bdc0ba3d421e7e267f41a5bddae9a1d625e7576b: 리뷰 작성에 자기가 구매한 상품인지 확인하는 로직 추가
      - a0e0b2f77009887a34db186aa80206dac3d7d4e3: 리뷰 작성 하나만 할 수 있도록 로직 추가

## To reviewers

자세히 봐주세요.

