### PR TITLE
Refactor/wishlist 리스트 내림차순으로 출력하도록 변경, 1대1 문의에서 사용할 구매내역 리스트 조회 기능 구현

### DIFF
--- a/travel/src/main/java/com/travel/order/controller/OrderController.java
+++ b/travel/src/main/java/com/travel/order/controller/OrderController.java
@@ -42,6 +42,19 @@ public class OrderController {
         return ResponseEntity.ok(orders);
     }
 
+    @GetMapping("/qna")
+    public ResponseEntity<PageResponseDTO> getOrdersByQnA(@RequestParam(required = false, defaultValue = "1") int page, Authentication authentication) {
+        if (page < 1) {
+            throw new GlobalException(GlobalExceptionType.PAGE_INDEX_NOT_POSITIVE_NUMBER);
+        }
+
+        PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
+
+        PageResponseDTO orders = orderService.getOrdersByQnA(pageRequest, authentication.getName());
+
+        return ResponseEntity.ok(orders);
+    }
+
     @DeleteMapping("/{orderId}")
     public ResponseEntity<Void> deleteOrder(@PathVariable Long orderId, Authentication authentication) {
         orderService.deleteOrder(orderId, authentication.getName());

--- a/travel/src/main/java/com/travel/order/dto/response/OrderByQnAResponseDTO.java
+++ b/travel/src/main/java/com/travel/order/dto/response/OrderByQnAResponseDTO.java
@@ -1,0 +1,21 @@
+package com.travel.order.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OrderByQnAResponseDTO {
+
+    private Long orderId;
+
+    private Long purchasedProductId;
+
+    private String productName;
+
+    @Builder
+    public OrderByQnAResponseDTO(Long orderId, Long purchasedProductId, String productName) {
+        this.orderId = orderId;
+        this.purchasedProductId = purchasedProductId;
+        this.productName = productName;
+    }
+}

--- a/travel/src/main/java/com/travel/order/service/OrderService.java
+++ b/travel/src/main/java/com/travel/order/service/OrderService.java
@@ -13,6 +13,8 @@ public interface OrderService {
 
     PageResponseDTO getOrders(Pageable pageable, String userEmail);
 
+    PageResponseDTO getOrdersByQnA(Pageable pageable, String userEmail);
+
     void deleteOrder(Long orderId, String userEmail);
 
     PageResponseDTO getOrdersAdmin(Pageable pageable, String userEmail);

--- a/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
+++ b/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
@@ -11,10 +11,7 @@ import com.travel.order.dto.request.OrderApproveDTO;
 import com.travel.order.dto.request.OrderCreateDTO;
 import com.travel.order.dto.request.OrderCreateListDTO;
 import com.travel.order.dto.request.OrderNonMemberCreateDTO;
-import com.travel.order.dto.response.OrderAdminResponseDTO;
-import com.travel.order.dto.response.OrderListAdminResponseDTO;
-import com.travel.order.dto.response.OrderListResponseDTO;
-import com.travel.order.dto.response.OrderResponseDTO;
+import com.travel.order.dto.response.*;
 import com.travel.order.entity.Order;
 import com.travel.order.entity.OrderStatus;
 import com.travel.order.entity.PaymentMethod;
@@ -108,6 +105,33 @@ public class OrderServiceImpl implements OrderService {
         }
 
         return new PageResponseDTO(new PageImpl<>(orderListResponseDTOS.subList(start, end), pageable, orderListResponseDTOS.size()));
+    }
+
+    @Override
+    public PageResponseDTO getOrdersByQnA(Pageable pageable, String userEmail) {
+        Member member = memberRepository.findByMemberEmail(userEmail)
+                .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
+
+        List<Order> orderList = orderRepository.findByMember(member);
+
+        List<OrderByQnAResponseDTO> orderByQnAList = orderList.stream()
+                .flatMap(order -> purchasedProductRepository.findByOrder(order).stream()
+                        .map(purchasedProduct -> OrderByQnAResponseDTO.builder()
+                                .orderId(order.getOrderId())
+                                .purchasedProductId(purchasedProduct.getPurchasedProductId())
+                                .productName(purchasedProduct.getPurchasedProductName())
+                                .build())
+                )
+                .sorted(Comparator.comparing(OrderByQnAResponseDTO::getPurchasedProductId).reversed())
+                .collect(Collectors.toList());
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), orderByQnAList.size());
+        if (start > end) {
+            throw new GlobalException(GlobalExceptionType.PAGE_IS_EXCEEDED);
+        }
+
+        return new PageResponseDTO(new PageImpl<>(orderByQnAList.subList(start, end), pageable, orderByQnAList.size()));
     }
 
     @Override

--- a/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
+++ b/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
@@ -89,6 +89,7 @@ public class OrderServiceImpl implements OrderService {
 
                                 return purchasedProduct.toOrderResponseDTO(hasReview);
                             })
+                             .sorted(Comparator.comparing(OrderResponseDTO::getPurchasedProductId).reversed())
                             .collect(Collectors.toList());
 
                     return OrderListResponseDTO.builder()

--- a/travel/src/main/java/com/travel/wishlist/service/impl/WishlistServiceImpl.java
+++ b/travel/src/main/java/com/travel/wishlist/service/impl/WishlistServiceImpl.java
@@ -7,6 +7,7 @@ import com.travel.member.entity.Member;
 import com.travel.member.exception.MemberException;
 import com.travel.member.exception.MemberExceptionType;
 import com.travel.member.repository.MemberRepository;
+import com.travel.order.dto.response.OrderByQnAResponseDTO;
 import com.travel.product.entity.Product;
 import com.travel.product.exception.ProductException;
 import com.travel.product.exception.ProductExceptionType;
@@ -23,6 +24,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -65,6 +67,7 @@ public class WishlistServiceImpl implements WishlistService {
 
         List<WishlistResponseDTO> wishlistResponseDTOList = wishlists.stream()
                 .map(Wishlist::toResponseDTO)
+                .sorted(Comparator.comparing(WishlistResponseDTO::getWishilistId).reversed())
                 .collect(Collectors.toList());
 
         int start = (int) pageable.getOffset();


### PR DESCRIPTION
## Motivation

#177 
1대1 문의에서 사용할 구매내역 리스트 조회 기능 구현

#158 
리스트 내림차순으로 출력하도록 변경

## Key Changes

- Change 1
  - https://github.com/KDT3-Final-6/final-project-BE/issues/177
     - 542994f490466d44347c692004d87e685d9134d1: 1대1 문의에서 사용할 구매내역 리스트 조회 기능 구현
- Change 2
   - https://github.com/KDT3-Final-6/final-project-BE/issues/158
      - dbec543b1dc95913431e66fcfc44e2c5bbff7f10: Order 리스트 내림차순으로 출력하도록 변경
      - 9eb9849167a1eb0becdb717071fa1ac06f1f2407: Wishlist 리스트 내림차순으로 출력하도록 변경

## To reviewers

프론트에서 검색 결과 리스트는 내림차순으로 변경할 필요 없다고 해서 안 합니다.

