### PR TITLE
Bug/order: 비회원 주문시 같은 이메일로 주문할 때마다 멤버 생성되는 현상 수정

### DIFF
--- a/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
+++ b/travel/src/main/java/com/travel/order/service/impl/OrderServiceImpl.java
@@ -11,7 +11,10 @@ import com.travel.order.dto.request.OrderApproveDTO;
 import com.travel.order.dto.request.OrderCreateDTO;
 import com.travel.order.dto.request.OrderCreateListDTO;
 import com.travel.order.dto.request.OrderNonMemberCreateDTO;
-import com.travel.order.dto.response.*;
+import com.travel.order.dto.response.OrderAdminResponseDTO;
+import com.travel.order.dto.response.OrderByQnAResponseDTO;
+import com.travel.order.dto.response.OrderListResponseDTO;
+import com.travel.order.dto.response.OrderResponseDTO;
 import com.travel.order.entity.Order;
 import com.travel.order.entity.OrderStatus;
 import com.travel.order.entity.PaymentMethod;
@@ -89,7 +92,7 @@ public class OrderServiceImpl implements OrderService {
 
                                 return purchasedProduct.toOrderResponseDTO(hasReview);
                             })
-                             .sorted(Comparator.comparing(OrderResponseDTO::getPurchasedProductId).reversed())
+                            .sorted(Comparator.comparing(OrderResponseDTO::getPurchasedProductId).reversed())
                             .collect(Collectors.toList());
 
                     return OrderListResponseDTO.builder()
@@ -202,15 +205,15 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     public Order createOrderNonMember(OrderNonMemberCreateDTO orderNonMemberCreateDTO) {
-        Member member = Member.builder()
-                .memberName(orderNonMemberCreateDTO.getMemberName())
-                .memberEmail(orderNonMemberCreateDTO.getMemberEmail())
-                .build();
+        Member member = memberRepository.findByMemberEmail(orderNonMemberCreateDTO.getMemberEmail())
+                .orElse(Member.builder()
+                        .memberName(orderNonMemberCreateDTO.getMemberName())
+                        .memberEmail(orderNonMemberCreateDTO.getMemberEmail())
+                        .build());
 
         member.setNonMembers(true);
 
         memberRepository.save(member);
-
 
         List<PurchasedProduct> purchasedProductList = getPurchasedProducts(orderNonMemberCreateDTO.getProductIds());
 


### PR DESCRIPTION
## Motivation

#195
비회원 주문시 같은 이메일로 주문할 때마다 멤버 생성되는 현상 수정

## Key Changes

- Change 1
  - https://github.com/KDT3-Final-6/final-project-BE/issues/195
     - 82d084a4ebf0fb649913603dc7226440b93f36af: 비회원 주문시 이메일이 이미 멤버에 있는지 확인 후 로직 처리하도록 수정

## To reviewers

추후에 회원가입된 이메일이면 예외를 던지도록 수정할 예정입니다.

